### PR TITLE
Added volume service for a rotary encoder using ENC1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,7 @@ jobs:
     - run: ls judge/target/
     - run: mkdir staging && cp judge/target/*.jar staging/judge.jar
     - run: cp judge/target/*.zip staging/figures.zip
+    - run: zip -r volume_service.zip volume_service/* && cp volume_service.zip staging/
     - uses: actions/upload-artifact@v4
       with:
         name: Package

--- a/scripts/judge_update.sh
+++ b/scripts/judge_update.sh
@@ -70,7 +70,7 @@ if [ "$latest_tag" != "$last_release" ]; then
     fi
 
     if [ -f figures.zip ]; then
-        unzip -qu figures.zip -d /var/opt/judge
+        unzip -quo figures.zip -d /var/opt/judge
         rm figures.zip
         echo Installed/Upgraded judge figures to version $latest_tag
     fi
@@ -80,4 +80,27 @@ if [ "$latest_tag" != "$last_release" ]; then
     sudo systemctl start kiosk.service
 else
     echo "Latest version already installed"
+fi
+
+#now checking for volume service and install if not found
+if [ ! -d /var/opt/volume_service ]; then
+    if [ -f volume_service.zip ]; then
+      echo "Installing and starting volume service..."
+
+      echo Creating volume_service folder and extracting files...
+      sudo mkdir -p /var/opt/volume_service
+      sudo chown judge.judge /var/opt/volume_service
+      unzip -quoj volume_service.zip -d /var/opt/volume_service/
+      rm volume_service.zip
+
+      echo Starting volume service...
+      chmod +x /var/opt/volume_service/volume.service
+      sudo mv /var/opt/volume_service/volume.service /etc/systemd/system
+      sudo systemctl enable volume
+      sudo systemctl start volume
+
+    else
+      echo Latest release does not include the volume service
+    fi
+
 fi

--- a/volume_service/volume.py
+++ b/volume_service/volume.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+
+"""
+Source Credit: https://gist.github.com/savetheclocktower/9b5f67c20f6c04e65ed88f2e594d43c1
+
+The daemon responsible for changing the volume in response to a turn or press of the volume knob.
+
+The volume knob is a rotary encoder. It turns infinitely in either direction. Turning it to the
+right will increase the volume; turning it to the left will decrease the volume.
+
+The knob uses two GPIO pins and we need some extra logic to decode it. Rather than poll constantly, 
+we use threads and interrupts to listen to both pins in one script.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+
+from RPi import GPIO
+from queue import Queue
+
+DEBUG = False
+
+# SETTINGS
+# ========
+
+# The two pins that the encoder uses (BCM numbering).
+GPIO_A = 15
+GPIO_B = 18
+
+
+# The minimum and maximum volumes, as percentages.
+# The default max is less than 100 to prevent distortion.
+VOLUME_MIN = 20
+VOLUME_MAX = 96
+
+# The amount you want one click of the knob to increase or decrease the
+# volume. I don't think that non-integer values work here, but you're welcome
+# to try.
+VOLUME_INCREMENT = 1
+
+# (END SETTINGS)
+# 
+
+
+# When the knob is turned, the callback happens in a separate thread. If
+# those turn callbacks fire erratically or out of order, we'll get confused
+# about which direction the knob is being turned, so we'll use a queue to
+# enforce FIFO. The callback will push onto a queue, and all the actual
+# volume-changing will happen in the main thread.
+QUEUE = Queue()
+
+# When we put something in the queue, we'll use an event to signal to the
+# main thread that there's something in there. Then the main thread will
+# process the queue and reset the event. If the knob is turned very quickly,
+# this event loop will fall behind, but that's OK because it consumes the
+# queue completely each time through the loop, so it's guaranteed to catch up.
+EVENT = threading.Event()
+
+def debug(str):
+  if not DEBUG:
+    return
+  print(str)
+
+class RotaryEncoder:
+  """
+  A class to decode mechanical rotary encoder pulses.
+
+  Ported to RPi.GPIO from the pigpio sample here: 
+  http://abyz.co.uk/rpi/pigpio/examples.html
+  """
+  
+  def __init__(self, gpioA, gpioB, callback=None):
+    """
+    Instantiate the class. Takes three arguments: the two pin numbers to
+    which the rotary encoder is connected, plus a callback to run when the
+    switch is turned.
+    
+    The callback receives one argument: a `delta` that will be either 1 or -1.
+    One of them means that the dial is being turned to the right; the other
+    means that the dial is being turned to the left.
+    """
+    
+    self.lastGpio = None
+    self.gpioA    = gpioA
+    self.gpioB    = gpioB
+    self.callback = callback
+    
+    self.levA = 0
+    self.levB = 0
+    
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setup(self.gpioA, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    GPIO.setup(self.gpioB, GPIO.IN, pull_up_down=GPIO.PUD_UP)
+    
+    GPIO.add_event_detect(self.gpioA, GPIO.BOTH, self._callback)
+    GPIO.add_event_detect(self.gpioB, GPIO.BOTH, self._callback)
+    
+    
+  def destroy(self):
+    GPIO.remove_event_detect(self.gpioA)
+    GPIO.remove_event_detect(self.gpioB)
+    GPIO.cleanup()
+    
+  def _callback(self, channel):
+    level = GPIO.input(channel)
+    if channel == self.gpioA:
+      self.levA = level
+    else:
+      self.levB = level
+      
+    # Debounce.
+    if channel == self.lastGpio:
+      return
+    
+    # When both inputs are at 1, we'll fire a callback. If A was the most
+    # recent pin set high, it'll be forward, and if B was the most recent pin
+    # set high, it'll be reverse.
+    self.lastGpio = channel
+    if channel == self.gpioA and level == 1:
+      if self.levB == 1:
+        self.callback(1)
+    elif channel == self.gpioB and level == 1:
+      if self.levA == 1:
+        self.callback(-1)
+
+class VolumeError(Exception):
+  pass
+
+class Volume:
+  """
+  A wrapper API for interacting with the volume settings on the RPi.
+  """
+  MIN = VOLUME_MIN
+  MAX = VOLUME_MAX
+  INCREMENT = VOLUME_INCREMENT
+  
+  def __init__(self):
+    # Set an initial value for last_volume in case we're muted when we start.
+    self.last_volume = self.MIN
+    self._sync()
+  
+  def up(self):
+    """
+    Increases the volume by one increment.
+    """
+    return self.change(self.INCREMENT)
+    
+  def down(self):
+    """
+    Decreases the volume by one increment.
+    """
+    return self.change(-self.INCREMENT)
+    
+  def change(self, delta):
+    v = self.volume + delta
+    v = self._constrain(v)
+    return self.set_volume(v)
+  
+  def set_volume(self, v):
+    """
+    Sets volume to a specific value.
+    """
+    self.volume = self._constrain(v)
+    output = self.amixer("set 'PCM' unmute {}%".format(v))
+    self._sync(output)
+    return self.volume
+    
+  def toggle(self):
+    """
+    Toggles muting between on and off.
+    """
+    if self.is_muted:
+      output = self.amixer("set 'PCM' unmute")
+    else:
+      # We're about to mute ourselves, so we should remember the last volume
+      # value we had because we'll want to restore it later.
+      self.last_volume = self.volume
+      output = self.amixer("set 'PCM' mute")
+  
+    self._sync(output)
+    if not self.is_muted:
+      # If we just unmuted ourselves, we should restore whatever volume we
+      # had previously.
+      self.set_volume(self.last_volume)
+    return self.is_muted
+  
+  def status(self):
+    if self.is_muted:
+      return "{}% (muted)".format(self.volume)
+    return "{}%".format(self.volume)
+  
+  # Read the output of `amixer` to get the system volume and mute state.
+  #
+  # This is designed not to do much work because it'll get called with every
+  # click of the knob in either direction, which is why we're doing simple
+  # string scanning and not regular expressions.
+  def _sync(self, output=None):
+    if output is None:
+      output = self.amixer("get 'PCM'")
+      
+    lines = output.readlines()
+    if DEBUG:
+      strings = [line.decode('utf8') for line in lines]
+      debug("OUTPUT:")
+      debug("".join(strings))
+    last = lines[-1].decode('utf-8')
+    
+    # The last line of output will have two values in square brackets. The
+    # first will be the volume (e.g., "[95%]") and the second will be the
+    # mute state ("[off]" or "[on]").
+    i1 = last.rindex('[') + 1
+    i2 = last.rindex(']')
+
+    self.is_muted = last[i1:i2] == 'off'
+    
+    i1 = last.index('[') + 1
+    i2 = last.index('%')
+    # In between these two will be the percentage value.
+    pct = last[i1:i2]
+
+    self.volume = int(pct)
+  
+  # Ensures the volume value is between our minimum and maximum.
+  def _constrain(self, v):
+    if v < self.MIN:
+      return self.MIN
+    if v > self.MAX:
+      return self.MAX
+    return v
+    
+  def amixer(self, cmd):
+    p = subprocess.Popen("amixer {}".format(cmd), shell=True, stdout=subprocess.PIPE)
+    code = p.wait()
+    if code != 0:
+      raise VolumeError("Unknown error")
+      sys.exit(0)
+    
+    return p.stdout
+
+
+if __name__ == "__main__":
+  
+  gpioA = GPIO_A
+  gpioB = GPIO_B
+  
+  v = Volume()
+  
+  def on_press(value):
+    v.toggle()
+    debug("Toggled mute to: {}".format(v.is_muted))
+    EVENT.set()
+  
+  # This callback runs in the background thread. All it does is put turn
+  # events into a queue and flag the main thread to process them. The
+  # queueing ensures that we won't miss anything if the knob is turned
+  # extremely quickly.
+  def on_turn(delta):
+    QUEUE.put(delta)
+    EVENT.set()
+    
+  def consume_queue():
+    while not QUEUE.empty():
+      delta = QUEUE.get()
+      handle_delta(delta)
+  
+  def handle_delta(delta):
+    if v.is_muted:
+      debug("Unmuting")
+      v.toggle()
+    if delta == 1:
+      vol = v.up()
+    else:
+      vol = v.down()
+    debug("Set volume to: {}".format(vol))
+    
+  def on_exit(a, b):
+    debug("Exiting...")
+    encoder.destroy()
+    sys.exit(0)
+    
+  debug("Volume knob using pins {} and {}".format(gpioA, gpioB))
+  debug("Initial volume: {}".format(v.volume))
+
+  encoder = RotaryEncoder(GPIO_A, GPIO_B, callback=on_turn)
+  signal.signal(signal.SIGINT, on_exit)
+  
+  while True:
+    # This is the best way I could come up with to ensure that this script
+    # runs indefinitely without wasting CPU by polling. The main thread will
+    # block quietly while waiting for the event to get flagged. When the knob
+    # is turned we're able to respond immediately, but when it's not being
+    # turned we're not looping at all.
+    # 
+    # The 1200-second (20 minute) timeout is a hack; for some reason, if I
+    # don't specify a timeout, I'm unable to get the SIGINT handler above to
+    # work properly. But if there is a timeout set, even if it's a very long
+    # timeout, then Ctrl-C works as intended. No idea why.
+    EVENT.wait(1200)
+    consume_queue()
+    EVENT.clear()

--- a/volume_service/volume.service
+++ b/volume_service/volume.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Volume knob monitor
+
+[Service]
+User=root
+Group=root
+ExecStart=python /var/opt/volume_service/volume.py
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Updated build to include volume_service
- Borrowed code for volume control and modified to remove mute feature
- Volume service is set to use ENC1 (GPIO15 & 18) on the AeroJudge board
- Updated judge_update.sh script to install service if not found