### PR TITLE
Enable use of B/C direction option for unknowns

### DIFF
--- a/judge/src/main/resources/templates/judge_start_select.html
+++ b/judge/src/main/resources/templates/judge_start_select.html
@@ -54,7 +54,8 @@
                     <p class="black-text comp_action_text">KNOWN</p></a>
                 </div>
             
-                <div class="col s4"> <a th:id="'act_unknown'+${pilot.primary_id}" class="" th:href="@{/judge(pilot_id=${pilot.primary_id}, roundType='UNKNOWN', dirflip=false)}">
+                <div class="col s4"> <a th:id="'act_unknown'+${pilot.primary_id}" class="" th:href="@{/judge(pilot_id=${pilot.primary_id}, roundType='UNKNOWN', dirflip='false')}"
+                                        th:onmouseover="'this.href = this.href.replace(/dirflip=[^&]*/, \'dirflip=\' + $(\'#dirflip' + ${pilot.primary_id} + '\').val())'">
                     <i class="comp_action material-icons center">visibility_off</i>
                     <p class="black-text comp_action_text">UNKNOWN</p></a>
                 </div>


### PR DESCRIPTION
- Enabled use of B/C direction to be used for unknowns

This was a little tricky and had to use ChatGPT to help figure it out. I needed it to determine the direction chosen at the time the link was clicked. But since the main html form is used for knowns and this option uses a direct href, I needed a way to dynamically update the current value from dirflip. I tried a few options which didn't work so I asked ChatGPT for help. It provided this solution where just as you click the link, it updates the href with the value selected. This has been tested on an AeroJudge unit which works.