### PR TITLE
Changed figure name/description to have unknowns treated same as knowns

### DIFF
--- a/judge/src/main/resources/templates/judge.html
+++ b/judge/src/main/resources/templates/judge.html
@@ -104,10 +104,14 @@
                     <span th:if="${roundType eq 'KNOWN'}" th:text="'Dir ' + ${dirletter}"></span>
                 </div>
                 
+<!--
                 <h2 th:if="${roundType == 'KNOWN' or pilot_class == 'BASIC'}" th:text="'Figure '+${(iterStat.index + 1) + ' ' + maneuver.description}" style="line-height: 1rem ; margin: 1rem ;"
                     th:id="'description_'+ ${iterStat.index}">First Panel</h2>
                 <h2 th:if="${roundType == 'UNKNOWN' and pilot_class != 'BASIC'}" th:text="'Figure '+${iterStat.index + 1}" style="line-height: 1rem ; margin: 1rem ;"
-                            th:id="'description_'+ ${iterStat.index}">First Panel</h2>
+                    th:id="'description_'+ ${iterStat.index}">First Panel</h2>
+-->
+                <h2 th:text="'Figure '+${(iterStat.index + 1) + ' ' + maneuver.description}" style="line-height: 1rem ; margin: 1rem ;"
+                    th:id="'description_'+ ${iterStat.index}"></h2>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This will always include the description from Score for the figure name. If you only want it to say "Figure 1", "Figure 2", etc as it did before with unknowns, then leave the description field blank in score.