### PR TITLE
Updated class filter to be dynamic from pilots list

### DIFF
--- a/judge/src/main/resources/templates/class_filter_modal.html
+++ b/judge/src/main/resources/templates/class_filter_modal.html
@@ -19,64 +19,44 @@
         <div class="row center-align" style="margin-bottom: 10px;">
           <div class="col s12"><h4 class="heading">Class Select</h4></div>
         </div>
-        <div class="row" style="margin-bottom: 10px;">
-          <a class="col s5 btn orange darken-1 waves-effect waves-light" id="basic">Basic</a>
-          <a class="col s5 offset-s2 btn orange darken-1 waves-effect waves-light" id="sportsman">Sportsman</a>
+
+        <div class="row">
+          <div th:each="pilotClass : ${pilotClasses}" class="col s6 m6 l6" style="margin-bottom: 10px">
+              <a class="col s5 btn orange darken-1 waves-effect waves-light" style="width: 100%" 
+                  th:id="${pilotClass}" th:href="'/pilot-list-global?classFilter='+${pilotClass}">
+                  <span th:text="${pilotClass}" th:remove="tag"></span>
+              </a>
+          </div>
         </div>
+
         <div class="row" style="margin-bottom: 10px;">
-          <a class="col s5 btn orange darken-1 waves-effect waves-light" id="intermediate">Intermediate</a>
-          <a class="col s5 offset-s2 btn orange darken-1 waves-effect waves-light" id="advanced">Advanced</a>
-        </div>
-        <div class="row" style="margin-bottom: 10px;">
-          <a class="col s5 btn orange darken-1 waves-effect waves-light" id="unlimited">Unlimited</a>
-          <a class="col s5 offset-s2 btn orange darken-1 waves-effect waves-light" id="invitational">Invitational</a>
-          <!--<a class="col s5 offset-s2 btn orange darken-1 disabled waves-effect waves-light" id="freestyle">Freestyle</a>-->
-        </div>
-        <div class="row" style="margin-bottom: 10px;">
-          <a class="col s6 offset-s3 btn orange darken-1 waves-effect waves-light" id="global">Global List</a>
+          <a class="col s6 offset-s3 btn orange darken-1 waves-effect waves-light" id="global" href="/pilot-list-global">Global List</a>
         </div>
     </div>
   </div>
 
-  <!--  Scripts-->
-      <!--JavaScript at end of body for optimized loading-->
-      <script src="materialize/js/materialize.js"></script>
-      <script>
-        document.getElementById("basic").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "basic");
-          window.location.href = "/pilot-list-global?classFilter=basic";
-        });
+  <!--JavaScript at end of body for optimized loading-->
+  <script src="materialize/js/materialize.js"></script>
+  <script lang="javascript">
+    //On page load, capture the classFilter query parameter and store it in localStorage for the judge page to use
+    document.addEventListener("DOMContentLoaded", function () {
+        // Function to get query parameter from URL
+        function getQueryParam(param) {
+            const urlParams = new URLSearchParams(window.location.search);
+            return urlParams.get(param);
+        }
 
-        document.getElementById("sportsman").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "sportsman");
-          window.location.href = "/pilot-list-global?classFilter=sportsman";
-        });
+        // Retrieve classFilter from URL
+        const classFilter = getQueryParam("classFilter");
 
-        document.getElementById("intermediate").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "intermediate");
-          window.location.href = "/pilot-list-global?classFilter=intermediate";
-        });
-
-        document.getElementById("advanced").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "advanced");
-          window.location.href = "/pilot-list-global?classFilter=advanced";
-        });
-
-        document.getElementById("unlimited").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "unlimited");
-          window.location.href = "/pilot-list-global?classFilter=unlimited";
-        });
-
-        document.getElementById("invitational").addEventListener("click", function() {
-          localStorage.setItem("classFilter", "invitational");
-          window.location.href = "/pilot-list-global?classFilter=invitational";
-        });
-
-        document.getElementById("global").addEventListener("click", function() {
+        // Store classFilter in localStorage for judge page to use
+        if (classFilter) {
+          localStorage.setItem("classFilter", classFilter);
+        } else {
           localStorage.setItem("classFilter", "global");
-          window.location.href = "/pilot-list-global ";
-        });
+        }
+    });
 
-      </script>
+  </script>
 </body>
 </html>


### PR DESCRIPTION
- Pilot filter screen will now only show the pilot classes that are pulled from Score

This will improve those cases where not every class is flying during a competition. It just makes the filter screen a little less cluttered and avoids the case where a judge selects a class that is not being flown and has no pilots. Another benefit is when flying an "Invitational" competition, it automatically adds that filter (and any other potential class that Score may provide for).