### PR TITLE
Added score timeout settings, Added countdown timer to next info status update

### DIFF
--- a/judge/pom.xml
+++ b/judge/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>co.za.imac</groupId>
 	<artifactId>judge</artifactId>
-	<version>1.2</version>
+	<version>1.3</version>
 	<name>judge</name>
 	<description>AeroJudge</description>
 	<packaging>jar</packaging>

--- a/judge/src/main/java/co/za/imac/judge/dto/SettingDTO.java
+++ b/judge/src/main/java/co/za/imac/judge/dto/SettingDTO.java
@@ -6,35 +6,52 @@ public class SettingDTO {
     private String score_host = "192.168.1.4";
     private int score_http_port = 8181;
     private int line_number = 1;
+    private int score_poll_timeout = 2; //seconds
+    private int score_timeout = 10; //seconds
+    
+    public SettingDTO() {
+    }
     
     public int getLine_number() {
         return line_number;
     }
-
     public void setLine_number(int line_number) {
         this.line_number = line_number;
     }
 
-    public SettingDTO() {
-    }
-    
     public int getJudge_id() {
         return judge_id;
     }
     public void setJudge_id(int judge_id) {
         this.judge_id = judge_id;
     }
+
     public String getScore_host() {
         return score_host;
     }
     public void setScore_host(String score_host) {
         this.score_host = score_host;
     }
+
     public int getScore_http_port() {
         return score_http_port;
     }
     public void setScore_http_port(int score_http_port) {
         this.score_http_port = score_http_port;
+    }
+
+    public int getScore_poll_timeout() {
+        return score_poll_timeout;
+    }
+    public void setScore_poll_timeout(int score_poll_timeout) {
+        this.score_poll_timeout = score_poll_timeout;
+    }
+
+    public int getScore_timeout() {
+        return score_timeout;
+    }
+    public void setScore_timeout(int score_timeout) {
+        this.score_timeout = score_timeout;
     }
     
 }

--- a/judge/src/main/java/co/za/imac/judge/service/CompService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/CompService.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +61,8 @@ public class CompService {
         SettingDTO settingDTO = settingService.getSettings();
         COMP_INFO_DAT_URL = COMP_INFO_DAT_URL.replace("SCORE_HOST", settingDTO.getScore_host()).replace("SCORE_HTTP_PORT", String.valueOf(settingDTO.getScore_http_port()));
         try {
-            FileUtils.copyURLToFile(new URL(COMP_INFO_DAT_URL), new File(COMP_INFO_DAT_PATH),1000,1000);
+            int timeout = (int)Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis();
+            FileUtils.copyURLToFile(new URL(COMP_INFO_DAT_URL), new File(COMP_INFO_DAT_PATH),timeout,timeout);
         } catch (Exception e) {
             try {
                 // Score is probably turned off.
@@ -75,7 +77,8 @@ public class CompService {
         SettingDTO settingDTO = settingService.getSettings();
         COMP_PREFS_DAT_URL = COMP_PREFS_DAT_URL.replace("SCORE_HOST", settingDTO.getScore_host()).replace("SCORE_HTTP_PORT", String.valueOf(settingDTO.getScore_http_port()));
         try {
-            FileUtils.copyURLToFile(new URL(COMP_PREFS_DAT_URL), new File(COMP_PREFS_DAT_PATH),1000,1000);
+            int timeout = (int)Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis();
+            FileUtils.copyURLToFile(new URL(COMP_PREFS_DAT_URL), new File(COMP_PREFS_DAT_PATH),timeout,timeout);
         } catch (Exception e) {
             try {
                 // Score is probably turned off.

--- a/judge/src/main/java/co/za/imac/judge/service/InfoCollectorService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/InfoCollectorService.java
@@ -77,7 +77,7 @@ public class InfoCollectorService {
         try {
             String line;
             String essid = null;
-            String qualityPct = null;
+            String qualityPct = "";
 
             String osName = System.getProperty("os.name").toLowerCase();
             if (osName.contains("win")) {
@@ -105,7 +105,7 @@ public class InfoCollectorService {
                             int pct = (int) ((val * 100.0) / max);
                             qualityPct = String.valueOf(pct) + "%";
                         } catch (NumberFormatException e) {
-                            qualityPct = null;
+                            qualityPct = "0%";
                         }
                     }
                 }
@@ -141,14 +141,14 @@ public class InfoCollectorService {
     private InfoLine getScoreStatus () {
         // Check if score service is reachable
         try {
-            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build(); //short timeout for this
             SettingDTO settingDTO = settingService.getSettings();
+            HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(settingDTO.getScore_poll_timeout())).build();
 
             // Call a service within score to check if its available - this would best be a health check endpoint but score doesn't have one yet.
             String statusUrl = "http://" + settingDTO.getScore_host() + ":" + String.valueOf(settingDTO.getScore_http_port()) + "/scorepad/contest_info.dat";
             logger.debug("Checking score status at: " + statusUrl);
             HttpRequest statusRequest = HttpRequest.newBuilder()
-                .timeout(Duration.ofSeconds(5)) //short timeout for this
+                .timeout(Duration.ofSeconds(settingDTO.getScore_poll_timeout()))
                 .uri(URI.create(statusUrl)).build();
             HttpResponse<String> healthResponse = client.send(statusRequest, HttpResponse.BodyHandlers.ofString());
             logger.debug("Score status response code: " + healthResponse.statusCode());

--- a/judge/src/main/java/co/za/imac/judge/service/PilotService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/PilotService.java
@@ -9,6 +9,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,8 +64,9 @@ public class PilotService {
 
     public void getPilotsFileFromScore() throws MalformedURLException, IOException {
         SettingDTO settingDTO = settingService.getSettings();
+        int timeout = (int)Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis();
         PILOT_DAT_URL = PILOT_DAT_URL.replace("SCORE_HOST", settingDTO.getScore_host()).replace("SCORE_HTTP_PORT", String.valueOf(settingDTO.getScore_http_port()));
-        FileUtils.copyURLToFile(new URL(PILOT_DAT_URL), new File(PILOT_DAT_PATH),1000,1000);
+        FileUtils.copyURLToFile(new URL(PILOT_DAT_URL), new File(PILOT_DAT_PATH),timeout,timeout);
     }
 
     public boolean isPilots(){
@@ -339,7 +341,7 @@ public class PilotService {
         BufferedWriter bw = new BufferedWriter(fw);
         bw.write(xml);
         bw.close();
-        Unirest.setTimeouts(0, 0);
+        Unirest.setTimeouts(Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis(), Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis());
         HttpResponse<String> response = Unirest.post(SCORE_UPLOAD_URL)
                 .header("Accept-Language", "en-au")
                 .field("uploadtype", "flightdata")

--- a/judge/src/main/java/co/za/imac/judge/service/ScheduleService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/ScheduleService.java
@@ -25,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,8 +84,10 @@ public class ScheduleService {
     public void getSequenceFileFromScore() throws MalformedURLException, IOException {
         logger.info("Loading sequences from Score.");
         SettingDTO settingDTO = settingService.getSettings();
+        int timeout = (int)Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis();
+
         SEQUENCES_DAT_URL = SEQUENCES_DAT_URL.replace("SCORE_HOST", settingDTO.getScore_host()).replace("SCORE_HTTP_PORT", String.valueOf(settingDTO.getScore_http_port()));
-        FileUtils.copyURLToFile(new URL(SEQUENCES_DAT_URL), new File(SEQUENCES_DAT_PATH),1000,1000);
+        FileUtils.copyURLToFile(new URL(SEQUENCES_DAT_URL), new File(SEQUENCES_DAT_PATH),timeout,timeout);
     }
 
     /************

--- a/judge/src/main/java/co/za/imac/judge/service/SequenceService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/SequenceService.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -42,8 +43,10 @@ public class SequenceService {
 
     public void getSequenceFileFromScore() throws MalformedURLException, IOException {
         SettingDTO settingDTO = settingService.getSettings();
+        int timeout = (int)Duration.ofSeconds(settingDTO.getScore_timeout()).toMillis();
+
         SEQUENCES_DAT_URL = SEQUENCES_DAT_URL.replace("SCORE_HOST", settingDTO.getScore_host()).replace("SCORE_HTTP_PORT", String.valueOf(settingDTO.getScore_http_port()));
-        FileUtils.copyURLToFile(new URL(SEQUENCES_DAT_URL), new File(SEQUENCES_DAT_PATH),1000,1000);
+        FileUtils.copyURLToFile(new URL(SEQUENCES_DAT_URL), new File(SEQUENCES_DAT_PATH),timeout,timeout);
     }
 
     public boolean isSequence(){

--- a/judge/src/main/java/co/za/imac/judge/utils/CommandLineAppStartupRunner.java
+++ b/judge/src/main/java/co/za/imac/judge/utils/CommandLineAppStartupRunner.java
@@ -99,5 +99,7 @@ public class CommandLineAppStartupRunner implements ApplicationRunner {
         logger.info ("Line No.: " + settingDTO.getLine_number());
         logger.info ("Score Host: " + settingDTO.getScore_host());
         logger.info ("Score Port: " + settingDTO.getScore_http_port());
+        logger.info ("Score Timeout: " + settingDTO.getScore_timeout());
+        logger.info ("Score Poll Timeout: " + settingDTO.getScore_poll_timeout());
     }
 }

--- a/judge/src/main/resources/templates/banner.html
+++ b/judge/src/main/resources/templates/banner.html
@@ -34,6 +34,12 @@
           -webkit-tap-highlight-color: transparent; /* kills tap highlight on touch */
         }
 
+        .stscounter {
+          font-size: 0.8rem;
+          margin-left: 5px;
+          float: left;
+        }
+
         .info-icon {
           width: 20px;
           height: 20px;
@@ -107,6 +113,7 @@
 
       <div id="statusInfo" class="status-info right grey lighten-3 hidden" onclick="toggleStatus();">
         <span id="stsmsg">Please wait...</span>
+        <span id="stsctr" class="stscounter hidden">10</span>
         <span id="appName"></span> <span id="appVersion"></span><br/>
         <div id="dynamicLines"></div>
         <svg id="wifiIcon" class="wifi-icon" style="display:none;" viewBox="0 0 64 64">
@@ -143,15 +150,32 @@
       <script>
         let statusInfoInterval = null;
 
-        function startStatusInfoUpdates() {
-          // Start the interval every 10 seconds and store its ID
-          statusInfoInterval = setInterval(updateStatusInfo, 10000);
-        }
-
         function stopStatusInfoUpdates() {
           if (statusInfoInterval) {
             clearInterval(statusInfoInterval);
             statusInfoInterval = null;
+
+            const counter = document.getElementById("stsctr");
+            counter.textContent = "10"; // reset to 10 seconds
+            counter.classList.add("hidden");
+          }
+        }
+
+        function updateStatusCountdown() {
+          const counter = document.getElementById("stsctr");
+
+          if (counter.classList.contains("hidden")) {
+            counter.classList.remove("hidden");
+            counter.textContent = "10"; // reset to 10 seconds
+          } else {
+            let count = parseInt(counter.textContent);
+            if (count > 0) {
+              count -= 1;
+              counter.textContent = count.toString();
+            } else {
+              counter.classList.add("hidden");
+              updateStatusInfo();
+            }
           }
         }
 
@@ -163,8 +187,7 @@
           if (statusInfo.classList.contains("hidden")) {
             stopStatusInfoUpdates();
           } else {
-            updateStatusInfo();
-            startStatusInfoUpdates();
+            updateStatusInfo(); //poll the status info and start timer
           }
         }
 
@@ -224,6 +247,11 @@
 
         async function updateStatusInfo() {
           try {
+            if (statusInfoInterval) {
+              clearInterval(statusInfoInterval);
+              statusInfoInterval = null;
+            }
+
             const response = await $.ajax({
               url: "/api/getinfo",
               success: function (data) {
@@ -285,7 +313,13 @@
 
           } catch (errMsg) {
               M.toast({ html: 'Unable to get info', classes: 'toastMessage', displayLength: 4000 })
+          } finally {
+            // start countdown if not already running
+            if (!statusInfoInterval) {
+              statusInfoInterval = setInterval(updateStatusCountdown, 1000);
+            }
           }
+
         }
       </script>
     </div>


### PR DESCRIPTION
Added setting to allow control over when Score get/push calls timeout
Added setting to allow control over when Score info poll times out and defaulted to 2 seconds (quicker poll)
Added countdown timer to info status page to indicate when next poll occurs (helpful when leaving status info open for a period of time to know when it will update)