### PR TITLE
Add workspace files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,8 @@ hs_err_pid*
 
 ### VS Code ###
 .vscode/
+*.code-workspace
 
 ### Judge Files not needing to be tracked ###
 dockerbuild/settings.json
-.devcontainer/judge/*.code-workspace 
+.devcontainer/judge/ 

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ hs_err_pid*
 
 ### Judge Files not needing to be tracked ###
 dockerbuild/settings.json
-.devcontainer/judge/
+.devcontainer/judge/*.code-workspace 


### PR DESCRIPTION
Prevents VS Code workspace files from being tracked in Git