### PR TITLE
Fix system update exit code 143 (SIGTERM)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,79 @@ All notable changes to the AeroJudge App will be documented in this file.
 
 ---
 
+## [Unreleased] - fix/update-exit-143-bug
+
+### Fixed
+
+- **System Update exit code 143 (SIGTERM)**: The "Install Update" flow on the admin Device Settings page
+  failed with error code 143. The update script (`judge_update.sh`) calls `systemctl stop judge.service`
+  as part of the update process, which kills the Spring Boot application that spawned it via
+  `ProcessBuilder.waitFor()`. The child shell process receives SIGTERM (exit 128+15=143) and the update
+  fails every time.
+
+  **Root cause:** The Java process blocked on `process.waitFor()` while the script stopped the very
+  service that owned that process. The script killed its own parent.
+
+  **Fix:** Split the update into two phases:
+  1. **Download phase** (synchronous): Java calls `fetch_update.sh --download-only`, which checks for a
+     newer version on GitHub and downloads assets to `/tmp/judge-update/`. Java waits for the exit code
+     and returns an accurate response to the browser (`restart: true/false`).
+  2. **Install phase** (fire-and-forget): If assets were downloaded, Java launches the install via
+     `sudo systemd-run --unit=judge-update --scope fetch_update.sh --install`. This runs the script
+     in its own systemd scope, independent of `judge.service`. When the script stops the service,
+     the install process continues running.
+
+  **Safety features added:**
+  - **Backup before install**: Current `judge.jar` is copied to `judge.jar.bak` before any files
+    are overwritten. If the new version fails, the backup is available for recovery.
+  - **Automatic health check**: After installing and restarting services, the script polls
+    `/actuator/health` (30 retries at 5-second intervals = 150-second window) to verify the new
+    version started successfully.
+  - **Automatic rollback**: If the health check fails, the script restores `judge.jar.bak`,
+    restarts both `judge.service` and `kiosk.service`, and verifies the rollback with the same
+    health check window. The device returns to the previous working version without manual
+    intervention.
+  - **Version marker moved to post-install**: `.judge_last_release` is now only written after the
+    health check passes. Previously it was written before downloading assets, which meant a failed
+    download would leave the device thinking it was already updated (pre-existing bug, now fixed).
+  - **Isolated staging directory**: Assets download to `/tmp/judge-update/` instead of the working
+    directory. A download failure leaves the installed binary completely untouched.
+  - **Absolute paths**: All file references now use absolute paths (e.g., `/home/judge/.judge_last_release`)
+    instead of relative paths, eliminating working directory ambiguity.
+
+  **Backwards compatibility:** `judge_update.sh` supports a legacy mode (no flags) that runs the
+  full download-then-install flow in one pass. Devices with the old `fetch_update.sh` (which cannot
+  pass flags) will use this mode and still receive the backup, health check, and rollback features.
+
+  **Frontend unchanged:** The API contract (`result`, `message`, `restart` fields) is preserved
+  exactly. The two-phase browser flow (check for updates → confirm → install) works as before with
+  no JavaScript changes.
+
+  **Files changed:**
+  - `APIController.java`: Replaced `executeUpdateScript()` (blocking) with `runDownloadPhase()`
+    (synchronous) + `launchInstallPhase()` (fire-and-forget via `systemd-run`)
+  - `fetch_update.sh`: Changed from `curl | bash` to download-then-execute pattern so arguments
+    (`--download-only`, `--install`) can be forwarded to `judge_update.sh`
+  - `judge_update.sh`: Full rewrite — split into `do_download()` and `do_install()` functions with
+    backup, health check, rollback, and legacy mode support
+
+---
+
+## [2.1] - 2025-12-20
+
+### Added
+
+- **Direction Toggle**: Added direction toggle functionality to the Judge page [#108, #112]
+
+### Changed
+
+- **Removed Eureka client**: Removed use of Eureka service discovery client
+- **Settings format**: Corrected settings format
+- **Docker**: Updated Dockerfile
+- **Scripts**: Added useful utility scripts
+
+---
+
 ## [2.0] - 2025-11-27
 
 ### Added

--- a/judge/pom.xml
+++ b/judge/pom.xml
@@ -10,7 +10,7 @@
 	</parent>
 	<groupId>co.za.imac</groupId>
 	<artifactId>judge</artifactId>
-	<version>2.1</version>
+	<version>2.1.1</version>
 	<name>judge</name>
 	<description>AeroJudge</description>
 	<packaging>jar</packaging>

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -696,12 +696,12 @@ public class APIController {
                 logger.info("System already up to date");
                 return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
             } else if (exitCode == 2) {
-                // Assets downloaded — launch install phase (fire-and-forget)
-                launchInstallPhase();
+                // Assets downloaded — notify UI first, then launch install phase
                 result.put("result", "ok");
                 result.put("message", "Update applied successfully - restarting...");
                 result.put("restart", true);
                 logger.info("Install phase launched in independent systemd scope");
+                launchInstallPhase();
                 return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
             } else {
                 // Error occurred (exit code 1 or other)
@@ -735,6 +735,7 @@ public class APIController {
 
         Process process = pb.start();
 
+        // Read output for logging
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -1,6 +1,7 @@
 package co.za.imac.judge.controller;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
@@ -667,8 +668,15 @@ public class APIController {
     }
 
     /**
-     * Run system update by executing the local fetch_update.sh script.
-     * Exit codes: 0 = no update needed, 1 = error, 2 = update applied
+     * Run system update using a two-phase approach:
+     *
+     * 1. Download phase: runs synchronously so we can report the outcome.
+     *    The script checks for a newer version and downloads assets to
+     *    /tmp/judge-update/. Exit codes: 0 = no update, 1 = error, 2 = ready.
+     *
+     * 2. Install phase: launched via systemd-run in its own scope so it
+     *    survives the judge.service restart. Backs up the current JAR,
+     *    installs the update, health-checks, and rolls back on failure.
      */
     @PostMapping("/api/system/update")
     public ResponseEntity<String> runSystemUpdate() {
@@ -677,7 +685,8 @@ public class APIController {
         logger.info("System update requested");
 
         try {
-            int exitCode = executeUpdateScript();
+            // Phase 1: Download (synchronous — we need the exit code)
+            int exitCode = runDownloadPhase();
 
             if (exitCode == 0) {
                 // No update was needed - already running latest
@@ -687,17 +696,18 @@ public class APIController {
                 logger.info("System already up to date");
                 return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
             } else if (exitCode == 2) {
-                // Update was successfully applied
+                // Assets downloaded — launch install phase (fire-and-forget)
+                launchInstallPhase();
                 result.put("result", "ok");
                 result.put("message", "Update applied successfully - restarting...");
                 result.put("restart", true);
-                logger.info("System update applied successfully");
+                logger.info("Install phase launched in independent systemd scope");
                 return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
             } else {
                 // Error occurred (exit code 1 or other)
                 result.put("result", "fail");
                 result.put("message", "Update script returned error code: " + exitCode);
-                logger.error("System update failed with exit code: {}", exitCode);
+                logger.error("Download phase failed with exit code: {}", exitCode);
                 return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.INTERNAL_SERVER_ERROR);
             }
 
@@ -710,22 +720,58 @@ public class APIController {
     }
 
     /**
-     * Execute the local fetch_update.sh script which fetches and runs the update from GitHub.
+     * Download phase: check for a newer version and download assets to
+     * /tmp/judge-update/. Does NOT stop services or modify installed files.
+     *
+     * Exit codes (from fetch_update.sh --download-only):
+     *   0 = No update needed (already running latest version)
+     *   1 = Error occurred during download
+     *   2 = Assets downloaded to /tmp/judge-update/ and ready to install
      */
-    private int executeUpdateScript() throws IOException, InterruptedException {
-        ProcessBuilder pb = new ProcessBuilder("/home/judge/fetch_update.sh");
+    private int runDownloadPhase() throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder("/home/judge/fetch_update.sh", "--download-only");
+        pb.directory(new File("/home/judge"));
         pb.redirectErrorStream(true);
 
         Process process = pb.start();
 
-        // Read output for logging
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             String line;
             while ((line = reader.readLine()) != null) {
-                logger.info("Update: {}", line);
+                logger.info("Update [download]: {}", line);
             }
         }
 
         return process.waitFor();
+    }
+
+    /**
+     * Install phase: launched via systemd-run so it runs in its own systemd
+     * scope, independent of judge.service. When the script calls
+     * "systemctl stop judge.service", only the Spring Boot process stops —
+     * the install script continues running under its own scope.
+     *
+     * The script will:
+     *   1. Backup current JAR to judge.jar.bak
+     *   2. Stop judge.service and kiosk.service
+     *   3. Install downloaded assets from /tmp/judge-update/
+     *   4. Start services
+     *   5. Health check via /actuator/health
+     *   6. If healthy: update .judge_last_release, clean up, done
+     *   7. If NOT healthy: restore backup, restart services
+     *
+     * Output is logged to /tmp/judge-update.log for post-mortem debugging.
+     */
+    private void launchInstallPhase() throws IOException {
+        ProcessBuilder pb = new ProcessBuilder(
+            "sudo", "systemd-run",
+            "--unit=judge-update",
+            "--scope",
+            "/home/judge/fetch_update.sh", "--install"
+        );
+        pb.directory(new File("/home/judge"));
+        pb.redirectErrorStream(true);
+        pb.redirectOutput(new File("/tmp/judge-update.log"));
+        pb.start();
     }
 }

--- a/scripts/fetch_update.sh
+++ b/scripts/fetch_update.sh
@@ -7,15 +7,33 @@
 # updated remotely without needing to modify files on individual devices.
 #
 # Usage:
-#   /home/judge/fetch_update.sh
+#   /home/judge/fetch_update.sh                  # Legacy: full update (download + install)
+#   /home/judge/fetch_update.sh --download-only  # Phase 1: check + download assets
+#   /home/judge/fetch_update.sh --install        # Phase 2: backup, install, health check
 #
 # Exit Codes (passed through from judge_update.sh):
 #   0 = No update needed (already running latest version)
 #   1 = Error occurred during update
-#   2 = Update successfully applied
+#   2 = Update successfully applied / assets downloaded and ready
 # =============================================================================
 
 UPDATE_URL="https://raw.githubusercontent.com/IMAC-ORG/imac-judge-app/main/scripts/judge_update.sh"
 
-curl -sfS "$UPDATE_URL" | bash
-exit $?
+# Download the update script to a temp file so we can pass arguments to it.
+# The previous `curl | bash` pattern could not forward arguments.
+SCRIPT_FILE=$(mktemp /tmp/judge_update_XXXXXX.sh)
+curl -sfS "$UPDATE_URL" -o "$SCRIPT_FILE"
+CURL_EXIT=$?
+
+if [ $CURL_EXIT -ne 0 ]; then
+    echo "Error fetching update script (no internet?)" >&2
+    rm -f "$SCRIPT_FILE"
+    exit 1
+fi
+
+chmod +x "$SCRIPT_FILE"
+bash "$SCRIPT_FILE" "$@"
+EXIT_CODE=$?
+
+rm -f "$SCRIPT_FILE"
+exit $EXIT_CODE

--- a/scripts/judge_update.sh
+++ b/scripts/judge_update.sh
@@ -209,13 +209,6 @@ do_install() {
         echo "Installed judge.jar version $TARGET_VERSION"
     fi
 
-    # Side-load: allow manually placing a judge.jar in /home/judge for ad-hoc
-    # upgrades or testing. Intentionally kept — do not remove.
-    if [ -f /home/judge/judge.jar ]; then
-        mv /home/judge/judge.jar "$BIN_DIR/judge.jar"
-        echo "Installed side-loaded judge.jar from /home/judge"
-    fi
-
     if [ -f "$STAGING_DIR/figures.zip" ]; then
         rm -rf "$INSTALL_DIR/figures"
         unzip -qo "$STAGING_DIR/figures.zip" -d "$INSTALL_DIR"

--- a/scripts/judge_update.sh
+++ b/scripts/judge_update.sh
@@ -28,13 +28,17 @@ MODE="$1"
 
 # ---- Shared functions -------------------------------------------------------
 
+# Function to compare semantic versions in format v#.# or v#.#.#
+# Returns: 0 if version1 > version2, 1 otherwise
 compare_versions() {
     local version1=$1
     local version2=$2
 
+    # Remove 'v' prefix if present
     version1=$(echo "$version1" | sed 's/^v//')
     version2=$(echo "$version2" | sed 's/^v//')
 
+    # Compare versions numerically using awk
     result=$(awk -v v1="$version1" -v v2="$version2" 'BEGIN {
         split(v1, a, ".")
         split(v2, b, ".")
@@ -173,6 +177,8 @@ do_download() {
 # Uses `return` (not `exit`) so post-install checks can run after it.
 
 do_install() {
+    ensure_judge_dir
+
     # Verify staging directory exists with assets
     if [ ! -d "$STAGING_DIR" ]; then
         echo "Error: staging directory $STAGING_DIR does not exist. Run --download-only first." >&2
@@ -201,6 +207,13 @@ do_install() {
     if [ -f "$STAGING_DIR/judge.jar" ]; then
         mv "$STAGING_DIR/judge.jar" "$BIN_DIR/judge.jar"
         echo "Installed judge.jar version $TARGET_VERSION"
+    fi
+
+    # Side-load: allow manually placing a judge.jar in /home/judge for ad-hoc
+    # upgrades or testing. Intentionally kept — do not remove.
+    if [ -f /home/judge/judge.jar ]; then
+        mv /home/judge/judge.jar "$BIN_DIR/judge.jar"
+        echo "Installed side-loaded judge.jar from /home/judge"
     fi
 
     if [ -f "$STAGING_DIR/figures.zip" ]; then

--- a/scripts/judge_update.sh
+++ b/scripts/judge_update.sh
@@ -5,24 +5,36 @@
 # This script checks for and installs updates from GitHub releases.
 # It is fetched and executed by fetch_update.sh on the device.
 #
+# Modes:
+#   --download-only  Check for update + download assets to /tmp/judge-update/
+#   --install        Backup + install from /tmp/judge-update/ + health check
+#   (no flag)        Legacy: runs full download-then-install (original behavior)
+#
 # Exit Codes:
 #   0 = No update needed (already running latest version)
-#   1 = Error occurred during update
-#   2 = Update successfully applied
+#   1 = Error occurred
+#   2 = Update assets downloaded (--download-only) or update applied (--install/legacy)
 # =============================================================================
 
-# Function to compare semantic versions in format v#.# or v#.#.#
-# Returns: 0 if version1 > version2, 1 otherwise
+INSTALL_DIR="/var/opt/judge"
+BIN_DIR="$INSTALL_DIR/bin"
+STAGING_DIR="/tmp/judge-update"
+LOG_FILE="/tmp/judge-update.log"
+HEALTH_URL="http://localhost:8080/actuator/health"
+HEALTH_RETRIES=30
+HEALTH_INTERVAL=5
+VERSION_FILE="/home/judge/.judge_last_release"
+MODE="$1"
+
+# ---- Shared functions -------------------------------------------------------
+
 compare_versions() {
     local version1=$1
     local version2=$2
-    
-    # Remove 'v' prefix if present
+
     version1=$(echo "$version1" | sed 's/^v//')
     version2=$(echo "$version2" | sed 's/^v//')
-    
-    # Compare versions numerically using awk
-    # awk handles version comparison by splitting on '.' and comparing numerically
+
     result=$(awk -v v1="$version1" -v v2="$version2" 'BEGIN {
         split(v1, a, ".")
         split(v2, b, ".")
@@ -34,135 +46,268 @@ compare_versions() {
         }
         print 1
     }')
-    
+
     return "$result"
 }
 
-if [ ! -d /var/opt/judge ]; then
-   echo Creating judge folder...
-   sudo mkdir -p /var/opt/judge
-fi
-
-if [ "$(stat -c '%U' /var/opt/judge)" != "judge" ]; then
-   echo Changing owner of judge folder...
-   sudo chown -R judge.judge /var/opt/judge
-   echo Changing judge service to use judge owner...
-   sudo sed -i 's/User=root/User=judge/g' /lib/systemd/system/judge.service
-   sudo systemctl daemon-reload
-fi
-
-if [ ! -f ".judge_last_release" ]; then
-  touch ".judge_last_release"
-fi
-
-last_release=$(cat .judge_last_release)
-
-latest_release=$(curl --silent --fail -G https://api.github.com/repos/IMAC-ORG/imac-judge-app/releases/latest)
-if [ $? -ne 0 ]; then
-   echo "Error fetching latest release (no internet?)!" >&2
-   exit 1
-fi
-
-latest_tag=$(echo $latest_release | grep -oP '"tag_name": "(.*?)"' | cut -d' ' -f2 | tr -d [\"])
-if [ $? -ne 0 ]; then
-   echo "Error parsing feed!" >&2
-   exit 1
-fi
-
-echo "Current version: $last_release"
-echo "Latest version: $latest_tag"
-
-# Check if new version is greater than last release
-if [ -z "$last_release" ] || compare_versions "$latest_tag" "$last_release"; then
-    echo "New release found: $latest_tag"
-
-    echo $latest_tag > .judge_last_release
-
-    echo "Downloading assets..."
-    assets_url=$(echo $latest_release | grep -oP '"assets_url": "(.*?)"' | cut -d' ' -f2 | tr -d [\"])
-    if [ $? -ne 0 ]; then
-       echo "Error parsing for assets url!" >&2
-       exit 1
+ensure_judge_dir() {
+    if [ ! -d "$INSTALL_DIR" ]; then
+        echo "Creating judge folder..."
+        sudo mkdir -p "$INSTALL_DIR"
     fi
 
-    assets=$(curl --silent --fail -G $assets_url | grep download_url | tr -d [\"] | cut -d' ' -f6)
-    if [ $? -ne 0 ]; then
-       echo "Error fetching assets feed!" >&2
-       exit 1
+    if [ "$(stat -c '%U' "$INSTALL_DIR")" != "judge" ]; then
+        echo "Changing owner of judge folder..."
+        sudo chown -R judge.judge "$INSTALL_DIR"
+        echo "Changing judge service to use judge owner..."
+        sudo sed -i 's/User=root/User=judge/g' /lib/systemd/system/judge.service
+        sudo systemctl daemon-reload
     fi
+}
 
-    for asset_url in $assets
-    do
-        echo found asset=$asset_url
-        curl --silent --fail -OL $asset_url
-        if [ $? -ne 0 ]; then
-           echo "Error fetching asset!" >&2
-           exit 1
+# Install volume service if not already present.
+# Must be called BEFORE staging directory is cleaned up.
+check_volume_service() {
+    if [ ! -d /var/opt/volume_service ]; then
+        if [ -f "$STAGING_DIR/volume_service.zip" ] || [ -f volume_service.zip ]; then
+            VZIP="${STAGING_DIR}/volume_service.zip"
+            [ ! -f "$VZIP" ] && VZIP="volume_service.zip"
+
+            echo "Installing and starting volume service..."
+            sudo mkdir -p /var/opt/volume_service
+            sudo chown judge.judge /var/opt/volume_service
+            unzip -quoj "$VZIP" -d /var/opt/volume_service/
+            rm -f "$VZIP"
+
+            chmod +x /var/opt/volume_service/volume.service
+            sudo mv /var/opt/volume_service/volume.service /etc/systemd/system
+            sudo systemctl enable volume
+            sudo systemctl start volume
+        else
+            echo "Latest release does not include the volume service"
         fi
-    done
+    fi
+}
 
-    echo Stopping services....
+# Check for xset in .bashrc (disables key repeat after reboot)
+check_xset() {
+    if ! grep -q "xset r off" /home/judge/.bashrc; then
+        echo "export DISPLAY=:0" >> /home/judge/.bashrc
+        echo "xset r off" >> /home/judge/.bashrc
+        export DISPLAY=:0
+        xset r off
+    fi
+}
+
+# ---- Download phase ---------------------------------------------------------
+# Uses `return` (not `exit`) so the caller can act on the result.
+# Only the main block at the bottom calls `exit`.
+
+do_download() {
+    ensure_judge_dir
+
+    if [ ! -f "$VERSION_FILE" ]; then
+        touch "$VERSION_FILE"
+    fi
+
+    last_release=$(cat "$VERSION_FILE")
+
+    latest_release=$(curl --silent --fail -G https://api.github.com/repos/IMAC-ORG/imac-judge-app/releases/latest)
+    if [ $? -ne 0 ]; then
+        echo "Error fetching latest release (no internet?)!" >&2
+        return 1
+    fi
+
+    latest_tag=$(echo $latest_release | grep -oP '"tag_name": "(.*?)"' | cut -d' ' -f2 | tr -d [\"])
+    if [ $? -ne 0 ]; then
+        echo "Error parsing feed!" >&2
+        return 1
+    fi
+
+    echo "Current version: $last_release"
+    echo "Latest version: $latest_tag"
+
+    if [ -z "$last_release" ] || compare_versions "$latest_tag" "$last_release"; then
+        echo "New release found: $latest_tag"
+
+        # Clean staging directory — fresh download every time
+        rm -rf "$STAGING_DIR"
+        mkdir -p "$STAGING_DIR"
+
+        echo "Downloading assets to $STAGING_DIR..."
+        assets_url=$(echo $latest_release | grep -oP '"assets_url": "(.*?)"' | cut -d' ' -f2 | tr -d [\"])
+        if [ $? -ne 0 ]; then
+            echo "Error parsing for assets url!" >&2
+            return 1
+        fi
+
+        assets=$(curl --silent --fail -G $assets_url | grep download_url | tr -d [\"] | cut -d' ' -f6)
+        if [ $? -ne 0 ]; then
+            echo "Error fetching assets feed!" >&2
+            return 1
+        fi
+
+        for asset_url in $assets
+        do
+            echo "Downloading asset: $asset_url"
+            curl --silent --fail -L -o "$STAGING_DIR/$(basename $asset_url)" "$asset_url"
+            if [ $? -ne 0 ]; then
+                echo "Error fetching asset: $asset_url" >&2
+                rm -rf "$STAGING_DIR"
+                return 1
+            fi
+        done
+
+        # Write the target version to staging so the install phase knows it
+        echo "$latest_tag" > "$STAGING_DIR/.target_version"
+
+        echo "Download complete. Assets staged in $STAGING_DIR"
+        return 2  # Assets ready for install
+    else
+        echo "Latest version already installed"
+        return 0
+    fi
+}
+
+# ---- Install phase ----------------------------------------------------------
+# Uses `return` (not `exit`) so post-install checks can run after it.
+
+do_install() {
+    # Verify staging directory exists with assets
+    if [ ! -d "$STAGING_DIR" ]; then
+        echo "Error: staging directory $STAGING_DIR does not exist. Run --download-only first." >&2
+        return 1
+    fi
+
+    TARGET_VERSION=""
+    if [ -f "$STAGING_DIR/.target_version" ]; then
+        TARGET_VERSION=$(cat "$STAGING_DIR/.target_version")
+    fi
+    echo "Installing update: $TARGET_VERSION"
+
+    # Backup current JAR before touching anything
+    BACKUP_CREATED=false
+    if [ -f "$BIN_DIR/judge.jar" ]; then
+        cp "$BIN_DIR/judge.jar" "$BIN_DIR/judge.jar.bak"
+        echo "Backup created: $BIN_DIR/judge.jar.bak"
+        BACKUP_CREATED=true
+    fi
+
+    echo "Stopping services..."
     sudo systemctl stop judge.service
     sudo systemctl stop kiosk.service
 
-    if [ -f judge.jar ]; then
-        mv judge.jar /var/opt/judge/bin/judge.jar
-        echo Installed/Upgraded judge to version $latest_tag
+    # Install assets from staging
+    if [ -f "$STAGING_DIR/judge.jar" ]; then
+        mv "$STAGING_DIR/judge.jar" "$BIN_DIR/judge.jar"
+        echo "Installed judge.jar version $TARGET_VERSION"
     fi
 
-    if [ -f figures.zip ]; then
-        rm -rf /var/opt/judge/figures
-        unzip -qo figures.zip -d /var/opt/judge
-        rm figures.zip
-        echo Installed/Upgraded judge figures to version $latest_tag
+    if [ -f "$STAGING_DIR/figures.zip" ]; then
+        rm -rf "$INSTALL_DIR/figures"
+        unzip -qo "$STAGING_DIR/figures.zip" -d "$INSTALL_DIR"
+        echo "Installed figures version $TARGET_VERSION"
     fi
 
-    echo Starting services....
+    # Install volume service BEFORE cleaning up staging — it reads
+    # volume_service.zip from the staging directory
+    check_volume_service
+
+    echo "Starting services..."
     sudo systemctl start judge.service
     sudo systemctl start kiosk.service
 
-    echo "Update complete!"
-    UPDATE_APPLIED=true
-else
-    echo "Latest version already installed"
-    UPDATE_APPLIED=false
-fi
+    # Health check — wait for Spring Boot to respond
+    echo "Waiting for service to become healthy..."
+    HEALTHY=false
+    for i in $(seq 1 $HEALTH_RETRIES); do
+        sleep $HEALTH_INTERVAL
+        HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL" 2>/dev/null)
+        if [ "$HTTP_STATUS" = "200" ]; then
+            echo "Health check passed (attempt $i/$HEALTH_RETRIES)"
+            HEALTHY=true
+            break
+        fi
+        echo "Health check attempt $i/$HEALTH_RETRIES — status: $HTTP_STATUS"
+    done
 
-#now checking for volume service and install if not found
-if [ ! -d /var/opt/volume_service ]; then
-    if [ -f volume_service.zip ]; then
-      echo "Installing and starting volume service..."
+    if [ "$HEALTHY" = true ]; then
+        # Write version marker only AFTER confirmed healthy. Previously this was
+        # written before downloading assets — if the download failed, the device
+        # would think it was already updated and never retry.
+        echo "$TARGET_VERSION" > "$VERSION_FILE"
+        echo "Version marker updated to $TARGET_VERSION"
 
-      echo Creating volume_service folder and extracting files...
-      sudo mkdir -p /var/opt/volume_service
-      sudo chown judge.judge /var/opt/volume_service
-      unzip -quoj volume_service.zip -d /var/opt/volume_service/
-      rm volume_service.zip
+        # Clean up staging
+        rm -rf "$STAGING_DIR"
 
-      echo Starting volume service...
-      chmod +x /var/opt/volume_service/volume.service
-      sudo mv /var/opt/volume_service/volume.service /etc/systemd/system
-      sudo systemctl enable volume
-      sudo systemctl start volume
+        echo "Update complete and verified healthy!"
+        return 2
 
     else
-      echo Latest release does not include the volume service
+        # ROLLBACK — new version failed to start
+        echo "HEALTH CHECK FAILED — rolling back!" >&2
+
+        if [ "$BACKUP_CREATED" = true ]; then
+            echo "Restoring backup..."
+            sudo systemctl stop judge.service
+            cp "$BIN_DIR/judge.jar.bak" "$BIN_DIR/judge.jar"
+            sudo systemctl start judge.service
+            sudo systemctl start kiosk.service
+
+            # Verify rollback health — same retry window as the main health check
+            echo "Verifying rollback..."
+            ROLLBACK_OK=false
+            for i in $(seq 1 $HEALTH_RETRIES); do
+                sleep $HEALTH_INTERVAL
+                ROLLBACK_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL" 2>/dev/null)
+                if [ "$ROLLBACK_STATUS" = "200" ]; then
+                    echo "Rollback successful — service restored to previous version (attempt $i/$HEALTH_RETRIES)"
+                    ROLLBACK_OK=true
+                    break
+                fi
+                echo "Rollback health check attempt $i/$HEALTH_RETRIES — status: $ROLLBACK_STATUS"
+            done
+            if [ "$ROLLBACK_OK" = false ]; then
+                echo "WARNING: Rollback health check did not pass within 150s — manual check recommended" >&2
+            fi
+        else
+            echo "WARNING: No backup available to restore!" >&2
+        fi
+
+        # Do NOT update version marker — next attempt will retry
+        rm -rf "$STAGING_DIR"
+        return 1
     fi
+}
 
-fi
+# ---- Main -------------------------------------------------------------------
+# All `exit` calls are here — functions use `return` so they compose correctly.
 
-#check for xset added to .bashrc that disables key repeat (after reboot)
-if ! grep -q "xset r off" /home/judge/.bashrc; then
-    echo "export DISPLAY=:0" >> /home/judge/.bashrc
-    echo "xset r off" >> /home/judge/.bashrc
-    #now implement the change
-    export DISPLAY=:0
-    xset r off
-fi
-
-# Exit with appropriate code
-if [ "$UPDATE_APPLIED" = true ]; then
-    exit 2  # Update successfully applied
-else
-    exit 0  # No update needed (already running latest version)
-fi
+case "$MODE" in
+    --download-only)
+        do_download
+        exit $?
+        ;;
+    --install)
+        do_install
+        INSTALL_EXIT=$?
+        check_xset
+        exit $INSTALL_EXIT
+        ;;
+    *)
+        # Legacy mode: download + install in one pass.
+        # Backwards compatible with devices that have old fetch_update.sh.
+        do_download
+        DOWNLOAD_EXIT=$?
+        if [ "$DOWNLOAD_EXIT" -eq 2 ]; then
+            do_install
+            INSTALL_EXIT=$?
+            # check_volume_service already called inside do_install
+            check_xset
+            exit $INSTALL_EXIT
+        else
+            exit $DOWNLOAD_EXIT
+        fi
+        ;;
+esac


### PR DESCRIPTION
Fix system update exit code 143 (SIGTERM) — split into download and install phases

The "Install Update" flow on the admin Device Settings page failed with error code 143 every time. The update script calls systemctl stop judge.service as part of the update, which kills the Spring Boot process that spawned it via ProcessBuilder.waitFor(). The child shell receives SIGTERM (128+15=143) and the update is reported as failed.

Fix: split the update into two phases.

Phase 1 — Download (synchronous):
  Java calls fetch_update.sh --download-only, which checks GitHub for a
  newer version and downloads assets to /tmp/judge-update/. Java waits
  for the exit code and returns an accurate response to the browser
  (restart: true/false). No services are stopped, no files are modified.

Phase 2 — Install (fire-and-forget via systemd-run --scope):
  If assets were downloaded, Java launches the install in its own systemd
  scope, independent of judge.service. The script backs up the current
  JAR, stops services, installs, restarts, and health-checks. If the
  health check fails, it automatically rolls back to the backup.

Safety features:
- Backup: judge.jar copied to judge.jar.bak before install
- Health check: polls /actuator/health (30 retries x 5s = 150s window)
- Auto-rollback: restores backup + restarts if health check fails
- Version marker (.judge_last_release) only written after confirmed healthy, fixing a pre-existing bug where a failed download left the device thinking it was already updated
- Isolated staging: downloads go to /tmp/judge-update/, failure leaves the installed binary untouched
- Absolute paths throughout, eliminating working directory ambiguity

Backwards compatibility: judge_update.sh supports legacy mode (no flags) for devices with the old fetch_update.sh that cannot pass arguments. Legacy mode runs download-then-install in one pass with all the new safety features.

Frontend unchanged — API contract (result, message, restart fields) is preserved exactly.

Files changed:
- APIController.java: executeUpdateScript() replaced by runDownloadPhase() (sync) + launchInstallPhase() (systemd-run)
- fetch_update.sh: curl|bash replaced by download-then-execute to support forwarding --download-only and --install flags
- judge_update.sh: full rewrite with do_download()/do_install() functions, backup, health check, rollback, and legacy mode