### PR TITLE
Fix install phase: use --uid=judge to run update script as judge user

### DIFF
--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -761,7 +761,7 @@ public class APIController {
      *   6. If healthy: update .judge_last_release, clean up, done
      *   7. If NOT healthy: restore backup, restart services
      *
-     * Output is logged to /tmp/judge-update.log for post-mortem debugging.
+     * Output is logged to /var/opt/judge/judge-update.log for post-mortem debugging.
      */
     private void launchInstallPhase() throws IOException {
         ProcessBuilder pb = new ProcessBuilder(
@@ -772,7 +772,7 @@ public class APIController {
         );
         pb.directory(new File("/home/judge"));
         pb.redirectErrorStream(true);
-        pb.redirectOutput(new File("/tmp/judge-update.log"));
+        pb.redirectOutput(new File("/var/opt/judge/judge-update.log"));
         pb.start();
     }
 }

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -766,7 +766,7 @@ public class APIController {
     private void launchInstallPhase() throws IOException {
         ProcessBuilder pb = new ProcessBuilder(
             "sudo", "systemd-run",
-            "--unit=judge-update",
+            "--uid=judge",
             "--scope",
             "/home/judge/fetch_update.sh", "--install"
         );

--- a/judge/src/main/resources/templates/adminDevice.html
+++ b/judge/src/main/resources/templates/adminDevice.html
@@ -528,7 +528,7 @@
             if (data.restart) {
               // Update was applied and device is restarting
               $('#updateMessage').html('<span class="green-text">' + (data.message || 'Update applied successfully - restarting...') + '</span>');
-              M.toast({ html: 'Update successful - restarting...', classes: 'green', displayLength: 5000 });
+              M.toast({ html: 'Update successful - Please wait while restarting...', classes: 'green', displayLength: 20000 });
               setTimeout(function() {
                 window.location.reload();
               }, 15000);

--- a/judge/src/main/resources/templates/adminDevice.html
+++ b/judge/src/main/resources/templates/adminDevice.html
@@ -526,12 +526,42 @@
           $('#updateProgress').hide();
           if (data.result === "ok") {
             if (data.restart) {
-              // Update was applied and device is restarting
-              $('#updateMessage').html('<span class="green-text">' + (data.message || 'Update applied successfully - restarting...') + '</span>');
-              M.toast({ html: 'Update successful - Please wait while restarting...', classes: 'green', displayLength: 20000 });
-              setTimeout(function() {
-                window.location.reload();
-              }, 15000);
+              // Install phase launched — poll until service restarts, then verify version
+              $('#updateMessage').html('<span class="blue-text">Installing update — waiting for restart...</span>');
+              $('#updateProgress').show();
+              var pollAttempts = 0;
+              var maxAttempts = 40; // 40 x 5s = 200s max wait
+              var pollInterval = setInterval(function() {
+                pollAttempts++;
+                $.ajax({
+                  url: "/api/version",
+                  type: "GET",
+                  timeout: 3000,
+                  success: function(vData) {
+                    clearInterval(pollInterval);
+                    $('#updateProgress').hide();
+                    var newVersion = vData.appVersion || '';
+                    if (pendingUpdateVersion && newVersion === pendingUpdateVersion) {
+                      $('#updateMessage').html('<span class="green-text">Update successful — now running v' + newVersion + '</span>');
+                      M.toast({ html: 'Update successful — v' + newVersion, classes: 'green', displayLength: 5000 });
+                    } else {
+                      $('#updateMessage').html('<span class="red-text">Update failed — rolled back to v' + newVersion + '</span>');
+                      M.toast({ html: 'Update failed — rolled back to v' + newVersion, classes: 'red', displayLength: 5000 });
+                    }
+                    $('#runUpdate').removeClass('disabled');
+                    setTimeout(function() { window.location.reload(); }, 5000);
+                  },
+                  error: function() {
+                    if (pollAttempts >= maxAttempts) {
+                      clearInterval(pollInterval);
+                      $('#updateProgress').hide();
+                      $('#updateMessage').html('<span class="orange-text">Service has not responded — check device manually</span>');
+                      M.toast({ html: 'Service not responding — check device', classes: 'orange', displayLength: 5000 });
+                      $('#runUpdate').removeClass('disabled');
+                    }
+                  }
+                });
+              }, 5000);
             } else {
               // No update needed (script returned exit 0)
               $('#updateMessage').html('<span class="green-text">' + (data.message || 'Already up to date') + '</span>');

--- a/scripts/judge_update.sh
+++ b/scripts/judge_update.sh
@@ -201,7 +201,6 @@ do_install() {
 
     echo "Stopping services..."
     sudo systemctl stop judge.service
-    sudo systemctl stop kiosk.service
 
     # Install assets from staging
     if [ -f "$STAGING_DIR/judge.jar" ]; then
@@ -221,7 +220,6 @@ do_install() {
 
     echo "Starting services..."
     sudo systemctl start judge.service
-    sudo systemctl start kiosk.service
 
     # Health check — wait for Spring Boot to respond
     echo "Waiting for service to become healthy..."
@@ -247,6 +245,9 @@ do_install() {
         # Clean up staging
         rm -rf "$STAGING_DIR"
 
+        # Refresh the kiosk browser to show the updated app
+        DISPLAY=:0 xdotool search --onlyvisible --class chromium key F5
+
         echo "Update complete and verified healthy!"
         return 2
 
@@ -259,7 +260,6 @@ do_install() {
             sudo systemctl stop judge.service
             cp "$BIN_DIR/judge.jar.bak" "$BIN_DIR/judge.jar"
             sudo systemctl start judge.service
-            sudo systemctl start kiosk.service
 
             # Verify rollback health — same retry window as the main health check
             echo "Verifying rollback..."
@@ -270,6 +270,8 @@ do_install() {
                 if [ "$ROLLBACK_STATUS" = "200" ]; then
                     echo "Rollback successful — service restored to previous version (attempt $i/$HEALTH_RETRIES)"
                     ROLLBACK_OK=true
+                    # Refresh the kiosk browser to show the restored app
+                    DISPLAY=:0 xdotool search --onlyvisible --class chromium key F5
                     break
                 fi
                 echo "Rollback health check attempt $i/$HEALTH_RETRIES — status: $ROLLBACK_STATUS"

--- a/scripts/restartjudge.sh
+++ b/scripts/restartjudge.sh
@@ -5,7 +5,7 @@ sudo systemctl restart judge.service
 
 echo "Waiting for service to become healthy..."
 HEALTH_URL="http://localhost:8080/actuator/health"
-HEALTH_RETRIES=300
+HEALTH_RETRIES=30
 HEALTH_INTERVAL=5
 HEALTHY=false
 for i in $(seq 1 $HEALTH_RETRIES); do

--- a/scripts/restartjudge.sh
+++ b/scripts/restartjudge.sh
@@ -1,5 +1,26 @@
 #!/bin/bash
 
-echo Restarting services....
-sudo systemctl start judge.service
-sudo systemctl start kiosk.service
+echo Restarting judge....
+sudo systemctl restart judge.service
+
+echo "Waiting for service to become healthy..."
+HEALTH_URL="http://localhost:8080/actuator/health"
+HEALTH_RETRIES=300
+HEALTH_INTERVAL=5
+HEALTHY=false
+for i in $(seq 1 $HEALTH_RETRIES); do
+    sleep $HEALTH_INTERVAL
+    HTTP_STATUS=$(curl --silent --output /dev/null --write-out "%{http_code}" "$HEALTH_URL" 2>/dev/null)
+    if [ "$HTTP_STATUS" = "200" ]; then
+        echo "Health check passed (attempt $i/$HEALTH_RETRIES)"
+        HEALTHY=true
+        break
+    fi
+    echo "Health check attempt $i/$HEALTH_RETRIES â€” status: $HTTP_STATUS"
+done
+if [ "$HEALTHY" = true ]; then
+    echo "Refreshing browser..."
+    DISPLAY=:0 xdotool search --onlyvisible --class chromium key F5
+else
+   echo "Judge not healthy!"
+fi


### PR DESCRIPTION
Replace --unit=judge-update with --uid=judge in systemd-run. sudo is retained so systemd-run can create the scope as root, but --uid=judge drops privileges to the judge user before executing the install script. This prevents installed files from being owned by root and avoids systemd unit name collisions on repeated update attempts.