### PR TITLE
Fix device_reset to preserve settings.json and use updated fetch_update.sh

### DIFF
--- a/scripts/device_reset.sh
+++ b/scripts/device_reset.sh
@@ -9,14 +9,18 @@ sudo chown -R judge.judge /var/opt/judge
 sudo chmod -R go-w /var/opt/judge/
 
 cd /var/opt/judge
-rm *.log *.dat *.json *.zip
+rm *.log *.dat *.zip *.json
 rm pilots/scores/*
 
 cd ~
 rm .judge_last_release  
-wget -O fetch_update.sh https://raw.githubusercontent.com/IMAC-ORG/imac-judge-app/main/scripts/fetch_update.sh
-chmod u+x fetch_update.sh
-./fetch_update.sh
+curl -sfS https://raw.githubusercontent.com/IMAC-ORG/imac-judge-app/main/scripts/fetch_update.sh -o /home/judge/fetch_update.sh
+chmod +x /home/judge/fetch_update.sh
+/home/judge/fetch_update.sh
+
+# Fix default network settings to match AeroJudge config
+# Comment out this line if running manually to keep the original (deprecated) defaults
+sed -i 's/"score_host":"192.168.1.4"/"score_host":"192.168.8.100"/;s/"score_http_port":8181/"score_http_port":80/' /var/opt/judge/settings.json
 
 # removes this script so it doesn't get accidentally run again
 rm device_reset.sh


### PR DESCRIPTION
Excluded settings.json from cleanup to prevent devices reverting to default (hardcoded) score IP and port. 

Switch from wget to curl with full paths for the current fetch_update script.