### PR TITLE
Admin pages overhaul: resolver wizard, gates, picker tiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,93 @@ All notable changes to the AeroJudge App will be documented in this file.
 
 ---
 
+## [Unreleased] - admin-pages-overhaul
+
+### Added
+
+- **Admin landing page** (`/admin`): New top-level admin menu with three full-width tile links —
+  Event Admin (`/admin/comp`), Score Fixes (`/admin/scores`), Device Settings (`/admin/device`).
+  Single Exit button in the header; no FAB nav inside the menu.
+- **Event name display**: The loaded comp's event name now shows bold and prominently on
+  `/admin` and on `/validate-sequences` (both success and issues states), closing the
+  test/live event confusion gap.
+- **Fix Missing Sequence**: New admin action to mark a pilot's missing seq 2 of a 2-sequence
+  KNOWN round as 0.0 (didn't fly). Used when the pilot didn't fly seq 2 (mechanical, scratch)
+  and a judge at the line didn't manually zero the figures. Backend
+  `POST /api/scores/fix-missing-sequence`. Reachable from the Resolve Mismatches wizard.
+- **Move Round eligibility checks**: Backend `POST /api/scores/move-round` now rejects 400
+  when the source has no extra round to give, or when either pilot has an unresolved missing
+  seq 2 — admin must run Fix Missing Sequence first. Failure response names the specific
+  pilot and the action to take.
+- **Zero-fill** (`/admin/scores/zero-fill`): New tile + wizard for catching a behind pilot up
+  to peers who have already flown a round. Used when a pilot had to miss a round (mechanical,
+  control issues, etc.). Sequential constraint enforced — must zero K+1 before K+2.
+  Backend `POST /api/scores/zero-fill`.
+- **Swap Round Scores** (`/admin/scores/swap`): New tile + wizard for swapping two pilots'
+  scores in a single round when the judge attributed each pilot's flight to the other. Both
+  records look valid so the detector can't surface this case; admin discovers it from a
+  judge report. Backend `POST /api/scores/swap-round`.
+- **Format-change preventive blocker**: 2-sequence → 1-sequence reconfig is rejected with
+  HTTP 409 when the data isn't in a clean state — any pilot mid-round in KNOWN
+  (`activeSequence == 2`), or any class with uneven KNOWN round counts. Modal lists per-rule
+  failures and links to Score Fixes. Pre-check on both `/api/comp/local` and
+  `/api/comp?edit=true`; new comp creation skipped (backupAllFiles wipes pilots first).
+- **Pre-sync mismatch modal**: Tapping the publish-icon FAB on `pilot-list-global` /
+  `pilot-list-round` now runs a pre-flight check against `/api/scores/mismatches`; if
+  anomalies are detected the modal lists them with equal-styling Get admin / Sync anyway
+  choices.
+
+### Changed
+
+- **Detection rewrite** (`/api/scores/mismatches`): Replaces the median/mode "expectedCount"
+  algorithm and the silent-drop gate (which only emitted when both `tooMany` AND `tooFew`
+  were non-empty — hiding single-sided gaps). New algorithm computes per-(class, roundType)
+  min/max/spread plus per-pilot incomplete-round detection (seq 1 present, seq 2 missing,
+  peer evidence required). Payload now exposes both `mismatches` (anomalous groups) and
+  `allGroups` (every group with at least one pilot, used by manual-fix and zero-fill
+  pickers). Anomaly tags (`count_gap`, `incomplete_round`) on each group.
+- **Move-round activeRound integrity** (production bug fix): Non-equal-count moves previously
+  bricked the affected pilots by force-writing both activeRounds to `destRound + 1`. Now
+  uses explicit `decrementActiveRound` (source) + `incrementActiveRound` (destination)
+  matching the delta of the move.
+- **Page renames**:
+  - `/admin/comp`: Scorekeeper Admin → **Event Admin**
+  - `/admin/scores`: Score Admin → **Score Fixes**
+  - `/admin/device`: Device Settings — unchanged
+- **Admin navigation simplified**: Cross-link cleanup on every admin page — separate
+  Scorekeeper / Device / Scores buttons replaced with a single Admin Menu button → `/admin`.
+  The previous "Home" button (a misnomer — `/` is the judging interface) becomes "Exit"
+  with the `exit_to_app` icon; FAB green-circle picks up the same icon swap. FAB cleanup on
+  `/admin/scores` and `/admin/device` removes the secondary `/admin/comp` settings entry.
+- **Score Fixes tile layout**: Stacked full-width tiles using `.admin-tile-link` /
+  `.admin-tile` / `.admin-tile-title` / `.admin-tile-text` (matching the admin landing). Tile
+  order: Resolve Mismatches, Swap Round Scores, Zero Unflown Rounds, Audit Log (placeholder).
+  The previously-placeholder Edit Scores tile is removed entirely.
+- **Pilot-list admin warning Continue button**: Now lands on `/admin` (the menu) instead of
+  `/admin/comp` directly.
+- **Resolver wizard** (`/admin/scores/resolve`): The single-page move-only flow is replaced
+  wholesale by a two-operation wizard. Detected-mismatch entry from the new detection
+  algorithm; manual entry via Force Round Edits for cases the detector can't surface from
+  data. Step 1 offers Fix Missing Sequence and Move Round side-by-side, with per-op greying
+  driven by the group's incomplete-round and count-spread state.
+- **DESIGN.md tier sweep**: All admin templates (admin landing, Event Admin, Device Settings,
+  Score Fixes, all wizards, sync-mismatch modal) now use the locked text-size tiers (1.5 /
+  1.75 / 1.9 / 2.1 rem) and spacing tiers from `.idea/DESIGN.md`. Inline icons unified to
+  1.5rem. Disabled-row contrast palette applied uniformly with `cursor: not-allowed`.
+- **`ContestClasses.ORDER` consolidation**: New `co.za.imac.judge.utils.ContestClasses`
+  utility is the single source of truth for the IMAC class-order constant. Duplicate copies
+  in `SequenceValidationService` and `RootController` removed.
+  `ContestClasses.orderIndex(...)` helper handles case-insensitive lookup with an
+  `ORDER.size()` fallback for null / unknown / FREESTYLE.
+- **`ScoreResolverService`**: Pure-logic resolver helpers extracted from `APIController` to a
+  new `@Service` class mirroring `SequenceValidationService`. Public methods: `getMismatches`,
+  `countRoundsForType`, `findUnresolvedMissingSeq2Round`. Controller is now a thin HTTP layer.
+
+The 21 commits on this branch are sequenced so each lands a single coherent concern that a
+reviewer can read in isolation.
+
+---
+
 ## [Unreleased] - fix/update-exit-143-bug
 
 ### Fixed

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -43,6 +44,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import co.za.imac.judge.utils.ContestClasses;
 import co.za.imac.judge.utils.SettingUtils;
 
 import co.za.imac.judge.service.CompService;
@@ -360,40 +362,49 @@ public class APIController {
 
     @GetMapping("/api/scores/mismatches")
     public ResponseEntity<String> getScoreMismatches() throws IOException, ParserConfigurationException, SAXException {
-        Map<String, Object> result = new HashMap<>();
-        List<Map<String, Object>> mismatches = new ArrayList<>();
-
-        // Get all pilots and their scores
         List<Pilot> pilots = pilotService.getPilots();
 
-        // Group pilots by class
+        List<Map<String, Object>> mismatches = new ArrayList<>();
+        List<Map<String, Object>> allGroups = new ArrayList<>();
+
         Map<String, List<Pilot>> pilotsByClass = new HashMap<>();
         for (Pilot pilot : pilots) {
-            String className = pilot.getClassString();
-            if (className == null) continue;
-            pilotsByClass.computeIfAbsent(className.toUpperCase(), k -> new ArrayList<>()).add(pilot);
+            pilotsByClass.computeIfAbsent(pilot.getClassString().toUpperCase(), k -> new ArrayList<>()).add(pilot);
         }
 
-        // Check each class for KNOWN and UNKNOWN round types
         String[] classRoundTypes = {"KNOWN", "UNKNOWN"};
-
-        for (String className : pilotsByClass.keySet()) {
-            List<Pilot> classPilots = pilotsByClass.get(className);
-
+        for (Map.Entry<String, List<Pilot>> entry : pilotsByClass.entrySet()) {
             for (String roundType : classRoundTypes) {
-                checkAndAddMismatches(classPilots, roundType, className, mismatches);
+                checkAndAddMismatches(entry.getValue(), roundType, entry.getKey(), mismatches, allGroups);
             }
         }
 
-        // Check FREESTYLE separately (cross-class, only runs once)
+        // FREESTYLE: cross-class virtual group
         List<Pilot> freestylePilots = pilots.stream()
                 .filter(p -> Boolean.TRUE.equals(p.getFreestyle()))
                 .toList();
         if (!freestylePilots.isEmpty()) {
-            checkAndAddMismatches(freestylePilots, "FREESTYLE", "FREESTYLE", mismatches);
+            checkAndAddMismatches(freestylePilots, "FREESTYLE", "FREESTYLE", mismatches, allGroups);
         }
 
+        // Sort by class order, then KNOWN -> UNKNOWN -> FREESTYLE within a class.
+        Comparator<Map<String, Object>> byClassOrder = (g1, g2) -> {
+            int classCmp = Integer.compare(
+                    ContestClasses.orderIndex((String) g1.get("className")),
+                    ContestClasses.orderIndex((String) g2.get("className")));
+            if (classCmp != 0) return classCmp;
+            String t1 = (String) g1.get("roundType");
+            String t2 = (String) g2.get("roundType");
+            int o1 = "KNOWN".equals(t1) ? 0 : "UNKNOWN".equals(t1) ? 1 : 2;
+            int o2 = "KNOWN".equals(t2) ? 0 : "UNKNOWN".equals(t2) ? 1 : 2;
+            return Integer.compare(o1, o2);
+        };
+        mismatches.sort(byClassOrder);
+        allGroups.sort(byClassOrder);
+
+        Map<String, Object> result = new HashMap<>();
         result.put("mismatches", mismatches);
+        result.put("allGroups", allGroups);
         return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
     }
 
@@ -445,80 +456,97 @@ public class APIController {
     }
 
     /**
-     * Helper method to check for round count mismatches and add to the list if found.
+     * Builds the (class, roundType) detection group and adds it to allGroups.
+     * Adds to mismatches when the group has a count gap (max - min &gt;= 2) or
+     * any pilot has an incomplete round. A spread of 0 or 1 with no incomplete
+     * rounds is a valid state and yields no mismatch entry.
      */
     private void checkAndAddMismatches(List<Pilot> pilots, String roundType, String className,
-                                       List<Map<String, Object>> mismatches) throws IOException {
-        // Get round counts for each pilot
-        Map<Pilot, Integer> roundCounts = new HashMap<>();
+                                       List<Map<String, Object>> mismatches,
+                                       List<Map<String, Object>> allGroups) throws IOException {
+        if (pilots.isEmpty()) return;
+
+        List<Map<String, Object>> pilotEntries = new ArrayList<>();
+        int minCount = Integer.MAX_VALUE;
+        int maxCount = Integer.MIN_VALUE;
+
         for (Pilot pilot : pilots) {
             PilotScores scores = pilotService.getPilotScores(pilot);
             int count = countRoundsForType(scores, roundType);
-            roundCounts.put(pilot, count);
+            Integer incompleteRound = "KNOWN".equalsIgnoreCase(roundType)
+                    ? findUnresolvedMissingSeq2Round(pilot, pilots)
+                    : null;
+
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("pilotId", pilot.getPrimary_id());
+            entry.put("name", pilot.getName());
+            entry.put("roundCount", count);
+            entry.put("incompleteRound", incompleteRound);
+            pilotEntries.add(entry);
+
+            if (count < minCount) minCount = count;
+            if (count > maxCount) maxCount = count;
         }
 
-        if (roundCounts.isEmpty()) return;
+        pilotEntries.sort((a, b) ->
+                ((String) a.get("name")).compareToIgnoreCase((String) b.get("name")));
 
-        // Find expected count using mode (most common value), or median if no clear mode
-        Map<Integer, Long> countFrequency = roundCounts.values().stream()
-                .collect(java.util.stream.Collectors.groupingBy(c -> c, java.util.stream.Collectors.counting()));
+        int spread = maxCount - minCount;
+        boolean hasIncomplete = pilotEntries.stream().anyMatch(e -> e.get("incompleteRound") != null);
 
-        // Find max frequency
-        long maxFreq = countFrequency.values().stream().max(Long::compare).orElse(0L);
+        List<String> anomalies = new ArrayList<>();
+        if (spread >= 2) anomalies.add("count_gap");
+        if (hasIncomplete) anomalies.add("incomplete_round");
 
-        // Count how many values have the max frequency
-        long countWithMaxFreq = countFrequency.values().stream().filter(f -> f == maxFreq).count();
+        Map<String, Object> group = new HashMap<>();
+        group.put("className", className);
+        group.put("roundType", roundType);
+        group.put("minCount", minCount);
+        group.put("maxCount", maxCount);
+        group.put("spread", spread);
+        group.put("anomalies", anomalies);
+        group.put("pilots", pilotEntries);
 
-        int expectedCount;
-        if (countWithMaxFreq == 1) {
-            // Clear mode - one value appears more than others
-            expectedCount = countFrequency.entrySet().stream()
-                    .filter(e -> e.getValue() == maxFreq)
-                    .map(Map.Entry::getKey)
-                    .findFirst()
-                    .orElse(0);
-        } else {
-            // No clear mode - use median
-            List<Integer> sortedCounts = roundCounts.values().stream()
-                    .sorted()
-                    .toList();
-            int mid = sortedCounts.size() / 2;
-            expectedCount = sortedCounts.get(mid);
+        allGroups.add(group);
+        if (!anomalies.isEmpty()) {
+            mismatches.add(group);
+        }
+    }
+
+    /**
+     * Returns the round number of the pilot's unresolved missing seq 2, or null.
+     * A round R qualifies iff the pilot has scored seq 1 of (R, KNOWN) but not
+     * seq 2, AND some other pilot in the same group has scored seq 2 of
+     * (R, KNOWN).
+     */
+    private Integer findUnresolvedMissingSeq2Round(Pilot pilot, List<Pilot> groupPilots) throws IOException {
+        PilotScores scores = pilotService.getPilotScores(pilot);
+        if (scores == null || scores.getScores() == null) return null;
+
+        Set<Integer> roundsWithSeq1 = new HashSet<>();
+        Set<Integer> roundsWithSeq2 = new HashSet<>();
+        for (PScore s : scores.getScores()) {
+            if (!"KNOWN".equalsIgnoreCase(s.getType())) continue;
+            if (s.getSequence() == 1) roundsWithSeq1.add(s.getRound());
+            else if (s.getSequence() == 2) roundsWithSeq2.add(s.getRound());
         }
 
-        // Find pilots that deviate
-        List<Map<String, Object>> tooMany = new ArrayList<>();
-        List<Map<String, Object>> tooFew = new ArrayList<>();
-
-        for (Map.Entry<Pilot, Integer> entry : roundCounts.entrySet()) {
-            Pilot pilot = entry.getKey();
-            int count = entry.getValue();
-
-            if (count > expectedCount) {
-                Map<String, Object> pilotInfo = new HashMap<>();
-                pilotInfo.put("pilotId", pilot.getPrimary_id());
-                pilotInfo.put("name", pilot.getName());
-                pilotInfo.put("roundCount", count);
-                tooMany.add(pilotInfo);
-            } else if (count < expectedCount) {
-                Map<String, Object> pilotInfo = new HashMap<>();
-                pilotInfo.put("pilotId", pilot.getPrimary_id());
-                pilotInfo.put("name", pilot.getName());
-                pilotInfo.put("roundCount", count);
-                tooFew.add(pilotInfo);
+        for (Integer round : roundsWithSeq1) {
+            if (roundsWithSeq2.contains(round)) continue;
+            for (Pilot peer : groupPilots) {
+                if (peer.getPrimary_id().equals(pilot.getPrimary_id())) continue;
+                PilotScores peerScores = pilotService.getPilotScores(peer);
+                if (peerScores == null || peerScores.getScores() == null) continue;
+                for (PScore ps : peerScores.getScores()) {
+                    if ("KNOWN".equalsIgnoreCase(ps.getType())
+                            && ps.getRound() == round
+                            && ps.getSequence() == 2) {
+                        return round;
+                    }
+                }
             }
         }
-
-        // Only report if there are resolvable mismatches (both source AND destination exist)
-        if (!tooMany.isEmpty() && !tooFew.isEmpty()) {
-            Map<String, Object> mismatch = new HashMap<>();
-            mismatch.put("className", className);
-            mismatch.put("roundType", roundType);
-            mismatch.put("expectedRounds", expectedCount);
-            mismatch.put("tooMany", tooMany);
-            mismatch.put("tooFew", tooFew);
-            mismatches.add(mismatch);
-        }
+        return null;
     }
 
     @PostMapping("/api/scores/move-round")

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -490,6 +490,94 @@ public class APIController {
         return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
     }
 
+    @PostMapping("/api/scores/fix-missing-sequence")
+    public ResponseEntity<String> fixMissingSequence(@RequestBody Map<String, Object> payload)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, Object> result = new HashMap<>();
+
+        String pilotId = (String) payload.get("pilotId");
+        String roundType = (String) payload.get("roundType");
+        int round = ((Number) payload.get("round")).intValue();
+
+        if (!"KNOWN".equalsIgnoreCase(roundType)) {
+            result.put("result", "fail");
+            result.put("message", "Fix Missing Sequence is only valid for KNOWN rounds.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        Pilot pilot = pilotService.getPilot(pilotId);
+        if (pilot == null) {
+            result.put("result", "fail");
+            result.put("message", "Pilot not found.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        PilotScores scores = pilotService.getPilotScores(pilot);
+
+        // Pilot must have seq 1 of (KNOWN, round) but not seq 2
+        boolean hasSeq1 = false;
+        boolean hasSeq2 = false;
+        for (PScore s : scores.getScores()) {
+            if ("KNOWN".equalsIgnoreCase(s.getType()) && s.getRound() == round) {
+                if (s.getSequence() == 1) hasSeq1 = true;
+                else if (s.getSequence() == 2) hasSeq2 = true;
+            }
+        }
+        if (!hasSeq1 || hasSeq2) {
+            result.put("result", "fail");
+            result.put("message", pilot.getName() + " has no missing seq 2 for KNOWN round " + round + ".");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        // Peer evidence: another pilot in the same class must have scored seq 2 of this round.
+        // Borrow that peer's figure count so the new PScore matches what the round was scored against.
+        int figureCount = -1;
+        for (Pilot peer : pilotService.getPilots()) {
+            if (peer.getPrimary_id().equals(pilotId)) continue;
+            if (!pilot.getClassString().equalsIgnoreCase(peer.getClassString())) continue;
+            PilotScores peerScores = pilotService.getPilotScores(peer);
+            if (peerScores == null || peerScores.getScores() == null) continue;
+            for (PScore ps : peerScores.getScores()) {
+                if ("KNOWN".equalsIgnoreCase(ps.getType())
+                        && ps.getRound() == round
+                        && ps.getSequence() == 2
+                        && ps.getScores() != null) {
+                    figureCount = ps.getScores().length;
+                    break;
+                }
+            }
+            if (figureCount != -1) break;
+        }
+        if (figureCount == -1) {
+            result.put("result", "fail");
+            result.put("message", "No peer pilot in this class has scored seq 2 of round " + round + " — nothing to borrow figure count from.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        int beforeCount = scoreResolverService.countRoundsForType(scores, roundType);
+        int beforeActiveRound = scores.getActiveRound(roundType);
+        int beforeActiveSeq = scores.getActiveSequence();
+
+        float[] zeros = new float[figureCount];
+        scores.getScores().add(new PScore(round, 2, zeros, "KNOWN"));
+
+        // Round complete — advance state
+        scores.incrementActiveRound(roundType);
+        scores.setActiveSequence(1);
+
+        pilotService.savePilotScoresToFile(scores);
+
+        logger.info("Fix Missing Sequence: pilot={} ({}), class={}, round={}, roundCount {} -> {}, activeRound {} -> {}, activeSequence {} -> {}",
+                pilot.getPrimary_id(), pilot.getName(), pilot.getClassString(), round,
+                beforeCount, scoreResolverService.countRoundsForType(scores, roundType),
+                beforeActiveRound, scores.getActiveRound(roundType),
+                beforeActiveSeq, scores.getActiveSequence());
+
+        result.put("result", "ok");
+        result.put("message", "Sequence marked as not flown.");
+        return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
+    }
+
     /**
      * Check for available updates by querying GitHub releases API.
      * Compares current version with latest release tag.

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -16,12 +16,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -44,13 +41,13 @@ import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
-import co.za.imac.judge.utils.ContestClasses;
 import co.za.imac.judge.utils.SettingUtils;
 
 import co.za.imac.judge.service.CompService;
 import co.za.imac.judge.service.InfoCollectorService;
 import co.za.imac.judge.service.PilotService;
 import co.za.imac.judge.service.ScheduleService;
+import co.za.imac.judge.service.ScoreResolverService;
 import co.za.imac.judge.service.SequenceService;
 import co.za.imac.judge.service.SettingService;
 
@@ -72,6 +69,8 @@ public class APIController {
     private InfoCollectorService infoCollectorService;
     @Autowired
     private ScheduleService scheduleService;
+    @Autowired
+    private ScoreResolverService scoreResolverService;
 
     @GetMapping("/api/comp")
     public CompDTO getComp() throws IOException, ParserConfigurationException, SAXException {
@@ -362,49 +361,7 @@ public class APIController {
 
     @GetMapping("/api/scores/mismatches")
     public ResponseEntity<String> getScoreMismatches() throws IOException, ParserConfigurationException, SAXException {
-        List<Pilot> pilots = pilotService.getPilots();
-
-        List<Map<String, Object>> mismatches = new ArrayList<>();
-        List<Map<String, Object>> allGroups = new ArrayList<>();
-
-        Map<String, List<Pilot>> pilotsByClass = new HashMap<>();
-        for (Pilot pilot : pilots) {
-            pilotsByClass.computeIfAbsent(pilot.getClassString().toUpperCase(), k -> new ArrayList<>()).add(pilot);
-        }
-
-        String[] classRoundTypes = {"KNOWN", "UNKNOWN"};
-        for (Map.Entry<String, List<Pilot>> entry : pilotsByClass.entrySet()) {
-            for (String roundType : classRoundTypes) {
-                checkAndAddMismatches(entry.getValue(), roundType, entry.getKey(), mismatches, allGroups);
-            }
-        }
-
-        // FREESTYLE: cross-class virtual group
-        List<Pilot> freestylePilots = pilots.stream()
-                .filter(p -> Boolean.TRUE.equals(p.getFreestyle()))
-                .toList();
-        if (!freestylePilots.isEmpty()) {
-            checkAndAddMismatches(freestylePilots, "FREESTYLE", "FREESTYLE", mismatches, allGroups);
-        }
-
-        // Sort by class order, then KNOWN -> UNKNOWN -> FREESTYLE within a class.
-        Comparator<Map<String, Object>> byClassOrder = (g1, g2) -> {
-            int classCmp = Integer.compare(
-                    ContestClasses.orderIndex((String) g1.get("className")),
-                    ContestClasses.orderIndex((String) g2.get("className")));
-            if (classCmp != 0) return classCmp;
-            String t1 = (String) g1.get("roundType");
-            String t2 = (String) g2.get("roundType");
-            int o1 = "KNOWN".equals(t1) ? 0 : "UNKNOWN".equals(t1) ? 1 : 2;
-            int o2 = "KNOWN".equals(t2) ? 0 : "UNKNOWN".equals(t2) ? 1 : 2;
-            return Integer.compare(o1, o2);
-        };
-        mismatches.sort(byClassOrder);
-        allGroups.sort(byClassOrder);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("mismatches", mismatches);
-        result.put("allGroups", allGroups);
+        Map<String, Object> result = scoreResolverService.getMismatches();
         return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
     }
 
@@ -441,112 +398,6 @@ public class APIController {
 
         // Versions are equal
         return false;
-    }
-
-    private int countRoundsForType(PilotScores scores, String roundType) {
-        if (scores == null || scores.getScores() == null) return 0;
-
-        Set<Integer> rounds = new HashSet<>();
-        for (PScore score : scores.getScores()) {
-            if (roundType.equalsIgnoreCase(score.getType())) {
-                rounds.add(score.getRound());
-            }
-        }
-        return rounds.size();
-    }
-
-    /**
-     * Builds the (class, roundType) detection group and adds it to allGroups.
-     * Adds to mismatches when the group has a count gap (max - min &gt;= 2) or
-     * any pilot has an incomplete round. A spread of 0 or 1 with no incomplete
-     * rounds is a valid state and yields no mismatch entry.
-     */
-    private void checkAndAddMismatches(List<Pilot> pilots, String roundType, String className,
-                                       List<Map<String, Object>> mismatches,
-                                       List<Map<String, Object>> allGroups) throws IOException {
-        if (pilots.isEmpty()) return;
-
-        List<Map<String, Object>> pilotEntries = new ArrayList<>();
-        int minCount = Integer.MAX_VALUE;
-        int maxCount = Integer.MIN_VALUE;
-
-        for (Pilot pilot : pilots) {
-            PilotScores scores = pilotService.getPilotScores(pilot);
-            int count = countRoundsForType(scores, roundType);
-            Integer incompleteRound = "KNOWN".equalsIgnoreCase(roundType)
-                    ? findUnresolvedMissingSeq2Round(pilot, pilots)
-                    : null;
-
-            Map<String, Object> entry = new HashMap<>();
-            entry.put("pilotId", pilot.getPrimary_id());
-            entry.put("name", pilot.getName());
-            entry.put("roundCount", count);
-            entry.put("incompleteRound", incompleteRound);
-            pilotEntries.add(entry);
-
-            if (count < minCount) minCount = count;
-            if (count > maxCount) maxCount = count;
-        }
-
-        pilotEntries.sort((a, b) ->
-                ((String) a.get("name")).compareToIgnoreCase((String) b.get("name")));
-
-        int spread = maxCount - minCount;
-        boolean hasIncomplete = pilotEntries.stream().anyMatch(e -> e.get("incompleteRound") != null);
-
-        List<String> anomalies = new ArrayList<>();
-        if (spread >= 2) anomalies.add("count_gap");
-        if (hasIncomplete) anomalies.add("incomplete_round");
-
-        Map<String, Object> group = new HashMap<>();
-        group.put("className", className);
-        group.put("roundType", roundType);
-        group.put("minCount", minCount);
-        group.put("maxCount", maxCount);
-        group.put("spread", spread);
-        group.put("anomalies", anomalies);
-        group.put("pilots", pilotEntries);
-
-        allGroups.add(group);
-        if (!anomalies.isEmpty()) {
-            mismatches.add(group);
-        }
-    }
-
-    /**
-     * Returns the round number of the pilot's unresolved missing seq 2, or null.
-     * A round R qualifies iff the pilot has scored seq 1 of (R, KNOWN) but not
-     * seq 2, AND some other pilot in the same group has scored seq 2 of
-     * (R, KNOWN).
-     */
-    private Integer findUnresolvedMissingSeq2Round(Pilot pilot, List<Pilot> groupPilots) throws IOException {
-        PilotScores scores = pilotService.getPilotScores(pilot);
-        if (scores == null || scores.getScores() == null) return null;
-
-        Set<Integer> roundsWithSeq1 = new HashSet<>();
-        Set<Integer> roundsWithSeq2 = new HashSet<>();
-        for (PScore s : scores.getScores()) {
-            if (!"KNOWN".equalsIgnoreCase(s.getType())) continue;
-            if (s.getSequence() == 1) roundsWithSeq1.add(s.getRound());
-            else if (s.getSequence() == 2) roundsWithSeq2.add(s.getRound());
-        }
-
-        for (Integer round : roundsWithSeq1) {
-            if (roundsWithSeq2.contains(round)) continue;
-            for (Pilot peer : groupPilots) {
-                if (peer.getPrimary_id().equals(pilot.getPrimary_id())) continue;
-                PilotScores peerScores = pilotService.getPilotScores(peer);
-                if (peerScores == null || peerScores.getScores() == null) continue;
-                for (PScore ps : peerScores.getScores()) {
-                    if ("KNOWN".equalsIgnoreCase(ps.getType())
-                            && ps.getRound() == round
-                            && ps.getSequence() == 2) {
-                        return round;
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     @PostMapping("/api/scores/move-round")
@@ -594,7 +445,7 @@ public class APIController {
         }
 
         // Determine destination round number
-        int destRound = countRoundsForType(destScores, roundType) + 1;
+        int destRound = scoreResolverService.countRoundsForType(destScores, roundType) + 1;
 
         // Add audit comment timestamp
         String auditComment = String.format("[%s] Round moved from pilot %s",
@@ -630,8 +481,8 @@ public class APIController {
         pilotService.savePilotScoresToFile(destScores);
 
         logger.info("Successfully moved round. Source now has {} {} rounds, dest has {} {} rounds",
-                countRoundsForType(sourceScores, roundType), roundType,
-                countRoundsForType(destScores, roundType), roundType);
+                scoreResolverService.countRoundsForType(sourceScores, roundType), roundType,
+                scoreResolverService.countRoundsForType(destScores, roundType), roundType);
 
         result.put("result", "ok");
         result.put("message", "Round moved successfully");

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -592,10 +592,10 @@ public class APIController {
         }
         sourceScores.setScores(remainingSourceScores);
 
-        // Update active round numbers for both pilots
-        int newActiveRound = destRound + 1;
-        sourceScores.setActiveRound(roundType, newActiveRound);
-        destScores.setActiveRound(roundType, newActiveRound);
+        // Source lost a round in the move
+        sourceScores.decrementActiveRound(roundType);
+        // Dest gained a round in the move
+        destScores.incrementActiveRound(roundType);
 
         // Save both pilots
         pilotService.savePilotScoresToFile(sourceScores);

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -85,7 +85,8 @@ public class APIController {
      * Accepts: sequences (int), sequenceType (String), score_mode (String)
      */
     @PostMapping("/api/comp/local")
-    public ResponseEntity<String> updateLocalCompSettings(@RequestBody CompDTO comp) throws IOException {
+    public ResponseEntity<String> updateLocalCompSettings(@RequestBody CompDTO comp)
+            throws IOException, ParserConfigurationException, SAXException {
         Map<String, Object> result = new HashMap<>();
 
         CompDTO currentComp = compService.getComp();
@@ -93,6 +94,13 @@ public class APIController {
             result.put("result", "fail");
             result.put("message", "No competition loaded. Load an event first.");
             return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        if (currentComp.getSequences() == 2 && comp.getSequences() == 1) {
+            Map<String, Object> blockPayload = scoreResolverService.evaluateFormatChangeBlock();
+            if (blockPayload != null) {
+                return new ResponseEntity<>(new Gson().toJson(blockPayload), HttpStatus.CONFLICT);
+            }
         }
 
         // Update only the local settings that were provided
@@ -127,7 +135,17 @@ public class APIController {
             throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
 
         Map<String, Object> result = new HashMap<>();
-        
+
+        if (editComp) {
+            CompDTO currentComp = compService.getComp();
+            if (currentComp != null && currentComp.getSequences() == 2 && comp.getSequences() == 1) {
+                Map<String, Object> blockPayload = scoreResolverService.evaluateFormatChangeBlock();
+                if (blockPayload != null) {
+                    return new ResponseEntity<>(new Gson().toJson(blockPayload), HttpStatus.CONFLICT);
+                }
+            }
+        }
+
         logger.debug("Comp data received:");
         logger.debug(new Gson().toJson(comp));
        

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -426,6 +426,32 @@ public class APIController {
         PilotScores sourceScores = pilotService.getPilotScores(sourcePilot);
         PilotScores destScores = pilotService.getPilotScores(destPilot);
 
+        int sourceCount = scoreResolverService.countRoundsForType(sourceScores, roundType);
+        int destCount = scoreResolverService.countRoundsForType(destScores, roundType);
+        if (sourceCount <= destCount) {
+            result.put("result", "fail");
+            result.put("message", sourcePilot.getName() + " has no extra round to give to " + destPilot.getName() + ".");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        List<Pilot> classPeers = pilotService.getPilots().stream()
+                .filter(p -> sourcePilot.getClassString().equalsIgnoreCase(p.getClassString()))
+                .toList();
+        Integer sourceMissing = scoreResolverService.findUnresolvedMissingSeq2Round(sourcePilot, classPeers);
+        if (sourceMissing != null) {
+            result.put("result", "fail");
+            result.put("message", sourcePilot.getName() + " has an unresolved missing sequence 2 of round "
+                    + sourceMissing + " — Fix Missing Sequence on " + sourcePilot.getName() + " first.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+        Integer destMissing = scoreResolverService.findUnresolvedMissingSeq2Round(destPilot, classPeers);
+        if (destMissing != null) {
+            result.put("result", "fail");
+            result.put("message", destPilot.getName() + " has an unresolved missing sequence 2 of round "
+                    + destMissing + " — Fix Missing Sequence on " + destPilot.getName() + " first.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
         // Find the scores to move (all sequences for that round+type)
         List<PScore> scoresToMove = new ArrayList<>();
         List<PScore> remainingSourceScores = new ArrayList<>();

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -578,6 +578,124 @@ public class APIController {
         return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
     }
 
+    @PostMapping("/api/scores/zero-fill")
+    public ResponseEntity<String> zeroFill(@RequestBody Map<String, Object> payload)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, Object> result = new HashMap<>();
+
+        String pilotId = (String) payload.get("pilotId");
+        String roundType = (String) payload.get("roundType");
+        int round = ((Number) payload.get("round")).intValue();
+
+        Pilot pilot = pilotService.getPilot(pilotId);
+        if (pilot == null) {
+            result.put("result", "fail");
+            result.put("message", "Pilot not found.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        boolean isFreestyle = "FREESTYLE".equalsIgnoreCase(roundType);
+        boolean isKnown = "KNOWN".equalsIgnoreCase(roundType);
+        List<Pilot> peers;
+        if (isFreestyle) {
+            peers = pilotService.getPilots().stream()
+                    .filter(p -> Boolean.TRUE.equals(p.getFreestyle()))
+                    .toList();
+        } else {
+            peers = pilotService.getPilots().stream()
+                    .filter(p -> pilot.getClassString().equalsIgnoreCase(p.getClassString()))
+                    .toList();
+        }
+
+        PilotScores scores = pilotService.getPilotScores(pilot);
+
+        if (isKnown) {
+            Integer blockingRound = scoreResolverService.findUnresolvedMissingSeq2Round(pilot, peers);
+            if (blockingRound != null) {
+                result.put("result", "fail");
+                result.put("message", pilot.getName() + " has an unresolved missing seq 2 of KNOWN round "
+                        + blockingRound + " — Fix Missing Sequence first.");
+                return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+            }
+        }
+
+        int targetCount = scoreResolverService.countRoundsForType(scores, roundType);
+
+        int maxPeerCount = -1;
+        for (Pilot peer : peers) {
+            if (peer.getPrimary_id().equals(pilotId)) continue;
+            PilotScores peerScores = pilotService.getPilotScores(peer);
+            int pc = scoreResolverService.countRoundsForType(peerScores, roundType);
+            if (pc > maxPeerCount) maxPeerCount = pc;
+        }
+
+        if (maxPeerCount == -1) {
+            result.put("result", "fail");
+            result.put("message", "No peers in this group — nothing to catch up to.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+        if (targetCount >= maxPeerCount) {
+            result.put("result", "fail");
+            result.put("message", pilot.getName() + " is already caught up.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+        if (round != targetCount + 1) {
+            result.put("result", "fail");
+            result.put("message", pilot.getName() + " must zero round " + (targetCount + 1)
+                    + " before round " + round + " (zero-fill is sequential).");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        int seq1FigureCount = -1;
+        int seq2FigureCount = -1;
+        for (Pilot peer : peers) {
+            if (peer.getPrimary_id().equals(pilotId)) continue;
+            PilotScores peerScores = pilotService.getPilotScores(peer);
+            if (peerScores == null || peerScores.getScores() == null) continue;
+            for (PScore ps : peerScores.getScores()) {
+                if (!roundType.equalsIgnoreCase(ps.getType())) continue;
+                if (ps.getRound() != round) continue;
+                if (ps.getScores() == null) continue;
+                if (ps.getSequence() == 1 && seq1FigureCount == -1) seq1FigureCount = ps.getScores().length;
+                else if (ps.getSequence() == 2 && seq2FigureCount == -1) seq2FigureCount = ps.getScores().length;
+            }
+        }
+        if (!isKnown) seq2FigureCount = -1;
+        boolean filledSeq2 = seq2FigureCount != -1;
+
+        int beforeCount = targetCount;
+        int beforeActiveRound = scores.getActiveRound(roundType);
+        int beforeActiveSeq = scores.getActiveSequence();
+
+        String typeUpper = roundType.toUpperCase();
+        scores.getScores().add(new PScore(round, 1, new float[seq1FigureCount], typeUpper));
+        if (filledSeq2) {
+            scores.getScores().add(new PScore(round, 2, new float[seq2FigureCount], typeUpper));
+        }
+
+        int compSequences = compService.getComp().getSequences();
+        if (!isKnown || compSequences == 1 || filledSeq2) {
+            scores.incrementActiveRound(roundType);
+            scores.setActiveSequence(1);
+        } else {
+            scores.setActiveSequence(2);
+        }
+
+        pilotService.savePilotScoresToFile(scores);
+
+        String sequencesFilled = filledSeq2 ? "1+2" : "1";
+        logger.info("Zero-fill: pilot={} ({}), class={}, type={}, round={}, sequences filled={}, roundCount {} -> {}, activeRound {} -> {}, activeSequence {} -> {}",
+                pilot.getPrimary_id(), pilot.getName(), pilot.getClassString(), roundType, round,
+                sequencesFilled,
+                beforeCount, scoreResolverService.countRoundsForType(scores, roundType),
+                beforeActiveRound, scores.getActiveRound(roundType),
+                beforeActiveSeq, scores.getActiveSequence());
+
+        result.put("result", "ok");
+        result.put("message", "Round zeroed.");
+        return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
+    }
+
     /**
      * Check for available updates by querying GitHub releases API.
      * Compares current version with latest release tag.

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -17,8 +17,11 @@ import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
@@ -719,6 +722,84 @@ public class APIController {
 
         result.put("result", "ok");
         result.put("message", "Round zeroed.");
+        return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
+    }
+
+    @PostMapping("/api/scores/swap-round")
+    public ResponseEntity<String> swapRound(@RequestBody Map<String, Object> payload)
+            throws IOException, ParserConfigurationException, SAXException {
+        Map<String, Object> result = new HashMap<>();
+
+        String pilotIdA = (String) payload.get("pilotIdA");
+        String pilotIdB = (String) payload.get("pilotIdB");
+        String roundType = (String) payload.get("roundType");
+        int round = ((Number) payload.get("round")).intValue();
+
+        if (Objects.equals(pilotIdA, pilotIdB)) {
+            result.put("result", "fail");
+            result.put("message", "Two distinct pilots are required.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        Pilot pilotA = pilotService.getPilot(pilotIdA);
+        Pilot pilotB = pilotService.getPilot(pilotIdB);
+        if (pilotA == null || pilotB == null) {
+            result.put("result", "fail");
+            result.put("message", "Pilot not found.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+        if (!pilotA.getClassString().equalsIgnoreCase(pilotB.getClassString())) {
+            result.put("result", "fail");
+            result.put("message", pilotA.getName() + " and " + pilotB.getName()
+                    + " are not in the same class.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        PilotScores aScores = pilotService.getPilotScores(pilotA);
+        PilotScores bScores = pilotService.getPilotScores(pilotB);
+
+        List<PScore> aMatching = new ArrayList<>();
+        List<PScore> aOther = new ArrayList<>();
+        for (PScore s : aScores.getScores()) {
+            if (roundType.equalsIgnoreCase(s.getType()) && s.getRound() == round) aMatching.add(s);
+            else aOther.add(s);
+        }
+        List<PScore> bMatching = new ArrayList<>();
+        List<PScore> bOther = new ArrayList<>();
+        for (PScore s : bScores.getScores()) {
+            if (roundType.equalsIgnoreCase(s.getType()) && s.getRound() == round) bMatching.add(s);
+            else bOther.add(s);
+        }
+
+        Set<Integer> aSeqs = new HashSet<>();
+        for (PScore s : aMatching) aSeqs.add(s.getSequence());
+        Set<Integer> bSeqs = new HashSet<>();
+        for (PScore s : bMatching) bSeqs.add(s.getSequence());
+        if (!aSeqs.equals(bSeqs)) {
+            result.put("result", "fail");
+            result.put("message", pilotA.getName() + " and " + pilotB.getName()
+                    + " have different sequence sets for " + roundType + " round " + round
+                    + " — fix incomplete round first.");
+            return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
+        }
+
+        List<PScore> aNew = new ArrayList<>(aOther);
+        aNew.addAll(bMatching);
+        List<PScore> bNew = new ArrayList<>(bOther);
+        bNew.addAll(aMatching);
+        aScores.setScores(aNew);
+        bScores.setScores(bNew);
+
+        pilotService.savePilotScoresToFile(aScores);
+        pilotService.savePilotScoresToFile(bScores);
+
+        logger.info("Swap Round: pilotA={} ({}), pilotB={} ({}), class={}, type={}, round={}, sequences={}",
+                pilotA.getPrimary_id(), pilotA.getName(),
+                pilotB.getPrimary_id(), pilotB.getName(),
+                pilotA.getClassString(), roundType, round, aSeqs);
+
+        result.put("result", "ok");
+        result.put("message", "Round scores swapped.");
         return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.OK);
     }
 

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -162,7 +162,8 @@ public class APIController {
 
         // fetch seqs
         sequenceService.getSequenceFileFromScore();
-        
+        scheduleService.populateSequences();
+
         CompDTO newComp = compService.createCompFromRequest(comp);
         if (newComp == null) {
             result.put("result", "fail");

--- a/judge/src/main/java/co/za/imac/judge/controller/APIController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/APIController.java
@@ -96,7 +96,7 @@ public class APIController {
             return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
         }
 
-        if (currentComp.getSequences() == 2 && comp.getSequences() == 1) {
+        if (currentComp.getSequences() != comp.getSequences()) {
             Map<String, Object> blockPayload = scoreResolverService.evaluateFormatChangeBlock();
             if (blockPayload != null) {
                 return new ResponseEntity<>(new Gson().toJson(blockPayload), HttpStatus.CONFLICT);
@@ -138,7 +138,7 @@ public class APIController {
 
         if (editComp) {
             CompDTO currentComp = compService.getComp();
-            if (currentComp != null && currentComp.getSequences() == 2 && comp.getSequences() == 1) {
+            if (currentComp != null && currentComp.getSequences() != comp.getSequences()) {
                 Map<String, Object> blockPayload = scoreResolverService.evaluateFormatChangeBlock();
                 if (blockPayload != null) {
                     return new ResponseEntity<>(new Gson().toJson(blockPayload), HttpStatus.CONFLICT);
@@ -456,7 +456,7 @@ public class APIController {
             return new ResponseEntity<>(new Gson().toJson(result), HttpStatus.BAD_REQUEST);
         }
 
-        List<Pilot> classPeers = pilotService.getPilots().stream()
+        List<Pilot> classPeers = pilotService.getPilots(true).stream()
                 .filter(p -> sourcePilot.getClassString().equalsIgnoreCase(p.getClassString()))
                 .toList();
         Integer sourceMissing = scoreResolverService.findUnresolvedMissingSeq2Round(sourcePilot, classPeers);
@@ -580,7 +580,7 @@ public class APIController {
         // Peer evidence: another pilot in the same class must have scored seq 2 of this round.
         // Borrow that peer's figure count so the new PScore matches what the round was scored against.
         int figureCount = -1;
-        for (Pilot peer : pilotService.getPilots()) {
+        for (Pilot peer : pilotService.getPilots(true)) {
             if (peer.getPrimary_id().equals(pilotId)) continue;
             if (!pilot.getClassString().equalsIgnoreCase(peer.getClassString())) continue;
             PilotScores peerScores = pilotService.getPilotScores(peer);
@@ -646,11 +646,11 @@ public class APIController {
         boolean isKnown = "KNOWN".equalsIgnoreCase(roundType);
         List<Pilot> peers;
         if (isFreestyle) {
-            peers = pilotService.getPilots().stream()
+            peers = pilotService.getPilots(true).stream()
                     .filter(p -> Boolean.TRUE.equals(p.getFreestyle()))
                     .toList();
         } else {
-            peers = pilotService.getPilots().stream()
+            peers = pilotService.getPilots(true).stream()
                     .filter(p -> pilot.getClassString().equalsIgnoreCase(p.getClassString()))
                     .toList();
         }

--- a/judge/src/main/java/co/za/imac/judge/controller/RootController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/RootController.java
@@ -452,6 +452,13 @@ public class RootController {
         return "adminDevice";
     }
 
+    @GetMapping("/admin")
+    public String admin(Model model) throws IOException {
+        SettingDTO settings = settingService.getSettings();
+        model.addAttribute("settings", settings);
+        return "admin";
+    }
+
     @GetMapping("/admin/scores")
     public String adminScores(Model model) throws IOException {
         SettingDTO settings = settingService.getSettings();

--- a/judge/src/main/java/co/za/imac/judge/controller/RootController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/RootController.java
@@ -2,7 +2,7 @@ package co.za.imac.judge.controller;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
+import co.za.imac.judge.utils.ContestClasses;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -117,9 +117,8 @@ public class RootController {
 
         //now get ordered list of classes for the filter dialog
         Set<String> pilot_classes = new LinkedHashSet<>();
-        List<String> orderedClasses = Arrays.asList("BASIC", "SPORTSMAN", "INTERMEDIATE", "ADVANCED", "UNLIMITED", "INVITATIONAL");
         //build ordered list of classes from those contained in the pilots list
-        for (String className : orderedClasses) {
+        for (String className : ContestClasses.ORDER) {
             if (pilots.stream().anyMatch(pilot -> className.equalsIgnoreCase(pilot.getClassString()))) {
                 pilot_classes.add(className);
             }
@@ -197,9 +196,8 @@ public class RootController {
 
         //now get ordered list of classes for the filter dialog
         Set<String> pilot_classes = new LinkedHashSet<>();
-        List<String> orderedClasses = Arrays.asList("BASIC", "SPORTSMAN", "INTERMEDIATE", "ADVANCED", "UNLIMITED", "INVITATIONAL");
         //build ordered list of classes from those contained in the pilots list
-        for (String className : orderedClasses) {
+        for (String className : ContestClasses.ORDER) {
             if (pilots.stream().anyMatch(pilot -> className.equalsIgnoreCase(pilot.getClassString()))) {
                 pilot_classes.add(className);
             }

--- a/judge/src/main/java/co/za/imac/judge/controller/RootController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/RootController.java
@@ -480,4 +480,11 @@ public class RootController {
         model.addAttribute("settings", settings);
         return "adminScoresZeroFill";
     }
+
+    @GetMapping("/admin/scores/swap")
+    public String adminScoresSwap(Model model) throws IOException {
+        SettingDTO settings = settingService.getSettings();
+        model.addAttribute("settings", settings);
+        return "adminScoresSwap";
+    }
 }

--- a/judge/src/main/java/co/za/imac/judge/controller/RootController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/RootController.java
@@ -453,9 +453,10 @@ public class RootController {
     }
 
     @GetMapping("/admin")
-    public String admin(Model model) throws IOException {
+    public String admin(Model model) throws IOException, ParserConfigurationException, SAXException {
         SettingDTO settings = settingService.getSettings();
         model.addAttribute("settings", settings);
+        model.addAttribute("compName", compService.getComp().getComp_name());
         return "admin";
     }
 

--- a/judge/src/main/java/co/za/imac/judge/controller/RootController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/RootController.java
@@ -473,4 +473,11 @@ public class RootController {
         model.addAttribute("settings", settings);
         return "adminScoresResolve";
     }
+
+    @GetMapping("/admin/scores/zero-fill")
+    public String adminScoresZeroFill(Model model) throws IOException {
+        SettingDTO settings = settingService.getSettings();
+        model.addAttribute("settings", settings);
+        return "adminScoresZeroFill";
+    }
 }

--- a/judge/src/main/java/co/za/imac/judge/controller/ValidationController.java
+++ b/judge/src/main/java/co/za/imac/judge/controller/ValidationController.java
@@ -1,6 +1,7 @@
 package co.za.imac.judge.controller;
 
 import co.za.imac.judge.dto.ValidationResult;
+import co.za.imac.judge.service.CompService;
 import co.za.imac.judge.service.PilotService;
 import co.za.imac.judge.service.ScheduleService;
 import co.za.imac.judge.service.SequenceService;
@@ -14,8 +15,10 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.xml.sax.SAXException;
 
 import jakarta.servlet.http.HttpSession;
+import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 
 /**
@@ -42,18 +45,22 @@ public class ValidationController {
     @Autowired
     private ScheduleService scheduleService;
 
+    @Autowired
+    private CompService compService;
+
     /**
      * Called after sync completes. Validates all sequences and redirects appropriately.
      * If issues found, shows the error screen.
      * If clean, redirects to normal flow.
      */
     @GetMapping("/validate-sequences")
-    public String validateSequences(Model model) throws IOException {
+    public String validateSequences(Model model) throws IOException, ParserConfigurationException, SAXException {
         logger.info("Running sequence validation...");
 
         ValidationResult result = validationService.validateAll();
 
         model.addAttribute("settings", settingService.getSettings());
+        model.addAttribute("compName", compService.getComp().getComp_name());
         model.addAttribute("issues", result.getIssues());
         model.addAttribute("hasErrors", result.hasErrors());
         model.addAttribute("hasWarnings", result.hasWarnings());

--- a/judge/src/main/java/co/za/imac/judge/dto/PilotScores.java
+++ b/judge/src/main/java/co/za/imac/judge/dto/PilotScores.java
@@ -130,6 +130,15 @@ public class PilotScores {
     }
 
     /**
+     * Decrement active round for a specific type.
+     * @param roundType KNOWN, UNKNOWN, or FREESTYLE
+     */
+    public void decrementActiveRound(String roundType) {
+        int current = getActiveRound(roundType);
+        setActiveRound(roundType, current - 1);
+    }
+
+    /**
      * Get the full activeRoundByType map (for JSON serialization).
      */
     public Map<String, Integer> getActiveRoundByType() {

--- a/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
@@ -40,7 +40,7 @@ public class ScoreResolverService {
      * competition class order, then KNOWN, UNKNOWN, FREESTYLE within a class.
      */
     public Map<String, Object> getMismatches() throws IOException, ParserConfigurationException, SAXException {
-        List<Pilot> pilots = pilotService.getPilots();
+        List<Pilot> pilots = pilotService.getPilots(true);
 
         List<Map<String, Object>> mismatches = new ArrayList<>();
         List<Map<String, Object>> allGroups = new ArrayList<>();
@@ -97,7 +97,7 @@ public class ScoreResolverService {
      */
     public Map<String, Object> evaluateFormatChangeBlock()
             throws IOException, ParserConfigurationException, SAXException {
-        List<Pilot> pilots = pilotService.getPilots();
+        List<Pilot> pilots = pilotService.getPilots(true);
 
         List<Map<String, Object>> rule1Failures = new ArrayList<>();
         Map<String, List<Pilot>> pilotsByClass = new HashMap<>();

--- a/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
@@ -1,0 +1,198 @@
+package co.za.imac.judge.service;
+
+import co.za.imac.judge.dto.PScore;
+import co.za.imac.judge.dto.Pilot;
+import co.za.imac.judge.dto.PilotScores;
+import co.za.imac.judge.utils.ContestClasses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.xml.parsers.ParserConfigurationException;
+import org.xml.sax.SAXException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Pure-logic resolver helpers. Reads pilot data via PilotService; emits the
+ * detection payload for /api/scores/mismatches and the per-pilot eligibility
+ * checks consumed by the resolver backends.
+ *
+ * <p>Mirrors the SequenceValidationService pattern: no own state, autowires
+ * the data services it needs.
+ */
+@Service
+public class ScoreResolverService {
+
+    @Autowired
+    private PilotService pilotService;
+
+    /**
+     * Builds the detection payload for /api/scores/mismatches: a map with
+     * "mismatches" (anomalous groups only) and "allGroups" (every (class,
+     * roundType) group with at least one pilot). Both arrays sorted by
+     * competition class order, then KNOWN, UNKNOWN, FREESTYLE within a class.
+     */
+    public Map<String, Object> getMismatches() throws IOException, ParserConfigurationException, SAXException {
+        List<Pilot> pilots = pilotService.getPilots();
+
+        List<Map<String, Object>> mismatches = new ArrayList<>();
+        List<Map<String, Object>> allGroups = new ArrayList<>();
+
+        Map<String, List<Pilot>> pilotsByClass = new HashMap<>();
+        for (Pilot pilot : pilots) {
+            pilotsByClass.computeIfAbsent(pilot.getClassString().toUpperCase(), k -> new ArrayList<>()).add(pilot);
+        }
+
+        String[] classRoundTypes = {"KNOWN", "UNKNOWN"};
+        for (Map.Entry<String, List<Pilot>> entry : pilotsByClass.entrySet()) {
+            for (String roundType : classRoundTypes) {
+                checkAndAddMismatches(entry.getValue(), roundType, entry.getKey(), mismatches, allGroups);
+            }
+        }
+
+        // FREESTYLE: cross-class virtual group
+        List<Pilot> freestylePilots = pilots.stream()
+                .filter(p -> Boolean.TRUE.equals(p.getFreestyle()))
+                .toList();
+        if (!freestylePilots.isEmpty()) {
+            checkAndAddMismatches(freestylePilots, "FREESTYLE", "FREESTYLE", mismatches, allGroups);
+        }
+
+        // Sort by class order, then KNOWN -> UNKNOWN -> FREESTYLE within a class.
+        Comparator<Map<String, Object>> byClassOrder = (g1, g2) -> {
+            int classCmp = Integer.compare(
+                    ContestClasses.orderIndex((String) g1.get("className")),
+                    ContestClasses.orderIndex((String) g2.get("className")));
+            if (classCmp != 0) return classCmp;
+            String t1 = (String) g1.get("roundType");
+            String t2 = (String) g2.get("roundType");
+            int o1 = "KNOWN".equals(t1) ? 0 : "UNKNOWN".equals(t1) ? 1 : 2;
+            int o2 = "KNOWN".equals(t2) ? 0 : "UNKNOWN".equals(t2) ? 1 : 2;
+            return Integer.compare(o1, o2);
+        };
+        mismatches.sort(byClassOrder);
+        allGroups.sort(byClassOrder);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("mismatches", mismatches);
+        result.put("allGroups", allGroups);
+        return result;
+    }
+
+    /**
+     * Counts the number of distinct rounds the pilot has scored for the
+     * given round type.
+     */
+    public int countRoundsForType(PilotScores scores, String roundType) {
+        if (scores == null || scores.getScores() == null) return 0;
+
+        Set<Integer> rounds = new HashSet<>();
+        for (PScore score : scores.getScores()) {
+            if (roundType.equalsIgnoreCase(score.getType())) {
+                rounds.add(score.getRound());
+            }
+        }
+        return rounds.size();
+    }
+
+    /**
+     * Returns the round number of the pilot's unresolved missing seq 2, or null.
+     * A round R qualifies iff the pilot has scored seq 1 of (R, KNOWN) but not
+     * seq 2, AND some other pilot in the same group has scored seq 2 of
+     * (R, KNOWN).
+     */
+    public Integer findUnresolvedMissingSeq2Round(Pilot pilot, List<Pilot> groupPilots) throws IOException {
+        PilotScores scores = pilotService.getPilotScores(pilot);
+        if (scores == null || scores.getScores() == null) return null;
+
+        Set<Integer> roundsWithSeq1 = new HashSet<>();
+        Set<Integer> roundsWithSeq2 = new HashSet<>();
+        for (PScore s : scores.getScores()) {
+            if (!"KNOWN".equalsIgnoreCase(s.getType())) continue;
+            if (s.getSequence() == 1) roundsWithSeq1.add(s.getRound());
+            else if (s.getSequence() == 2) roundsWithSeq2.add(s.getRound());
+        }
+
+        for (Integer round : roundsWithSeq1) {
+            if (roundsWithSeq2.contains(round)) continue;
+            for (Pilot peer : groupPilots) {
+                if (peer.getPrimary_id().equals(pilot.getPrimary_id())) continue;
+                PilotScores peerScores = pilotService.getPilotScores(peer);
+                if (peerScores == null || peerScores.getScores() == null) continue;
+                for (PScore ps : peerScores.getScores()) {
+                    if ("KNOWN".equalsIgnoreCase(ps.getType())
+                            && ps.getRound() == round
+                            && ps.getSequence() == 2) {
+                        return round;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Builds the (class, roundType) detection group and adds it to allGroups.
+     * Adds to mismatches when the group has a count gap (max - min &gt;= 2) or
+     * any pilot has an incomplete round. A spread of 0 or 1 with no incomplete
+     * rounds is a valid state and yields no mismatch entry.
+     */
+    private void checkAndAddMismatches(List<Pilot> pilots, String roundType, String className,
+                                       List<Map<String, Object>> mismatches,
+                                       List<Map<String, Object>> allGroups) throws IOException {
+        if (pilots.isEmpty()) return;
+
+        List<Map<String, Object>> pilotEntries = new ArrayList<>();
+        int minCount = Integer.MAX_VALUE;
+        int maxCount = Integer.MIN_VALUE;
+
+        for (Pilot pilot : pilots) {
+            PilotScores scores = pilotService.getPilotScores(pilot);
+            int count = countRoundsForType(scores, roundType);
+            Integer incompleteRound = "KNOWN".equalsIgnoreCase(roundType)
+                    ? findUnresolvedMissingSeq2Round(pilot, pilots)
+                    : null;
+
+            Map<String, Object> entry = new HashMap<>();
+            entry.put("pilotId", pilot.getPrimary_id());
+            entry.put("name", pilot.getName());
+            entry.put("roundCount", count);
+            entry.put("incompleteRound", incompleteRound);
+            pilotEntries.add(entry);
+
+            if (count < minCount) minCount = count;
+            if (count > maxCount) maxCount = count;
+        }
+
+        pilotEntries.sort((a, b) ->
+                ((String) a.get("name")).compareToIgnoreCase((String) b.get("name")));
+
+        int spread = maxCount - minCount;
+        boolean hasIncomplete = pilotEntries.stream().anyMatch(e -> e.get("incompleteRound") != null);
+
+        List<String> anomalies = new ArrayList<>();
+        if (spread >= 2) anomalies.add("count_gap");
+        if (hasIncomplete) anomalies.add("incomplete_round");
+
+        Map<String, Object> group = new HashMap<>();
+        group.put("className", className);
+        group.put("roundType", roundType);
+        group.put("minCount", minCount);
+        group.put("maxCount", maxCount);
+        group.put("spread", spread);
+        group.put("anomalies", anomalies);
+        group.put("pilots", pilotEntries);
+
+        allGroups.add(group);
+        if (!anomalies.isEmpty()) {
+            mismatches.add(group);
+        }
+    }
+}

--- a/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/ScoreResolverService.java
@@ -87,6 +87,86 @@ public class ScoreResolverService {
     }
 
     /**
+     * Evaluates whether the comp can safely change from 2-sequence to
+     * 1-sequence KNOWN. Returns the structured failure payload (with
+     * rule1Failures and rule2Failures lists) when blocked, or null when
+     * both rules pass.
+     *
+     * <p>Rule 1: no pilot has activeSequence == 2 in KNOWN.
+     * <p>Rule 2: within each class, all pilots have the same KNOWN round count.
+     */
+    public Map<String, Object> evaluateFormatChangeBlock()
+            throws IOException, ParserConfigurationException, SAXException {
+        List<Pilot> pilots = pilotService.getPilots();
+
+        List<Map<String, Object>> rule1Failures = new ArrayList<>();
+        Map<String, List<Pilot>> pilotsByClass = new HashMap<>();
+        Map<String, Integer> countByPilotId = new HashMap<>();
+
+        for (Pilot pilot : pilots) {
+            PilotScores scores = pilotService.getPilotScores(pilot);
+            if (scores == null) continue;
+
+            if (scores.getActiveSequence() == 2 && "KNOWN".equalsIgnoreCase(scores.getActiveRoundType())) {
+                Map<String, Object> entry = new HashMap<>();
+                entry.put("pilotId", pilot.getPrimary_id());
+                entry.put("name", pilot.getName());
+                entry.put("className", pilot.getClassString());
+                entry.put("round", scores.getActiveRound("KNOWN"));
+                rule1Failures.add(entry);
+            }
+
+            pilotsByClass.computeIfAbsent(pilot.getClassString().toUpperCase(), k -> new ArrayList<>()).add(pilot);
+            countByPilotId.put(pilot.getPrimary_id(), countRoundsForType(scores, "KNOWN"));
+        }
+
+        List<Map<String, Object>> rule2Failures = new ArrayList<>();
+        for (Map.Entry<String, List<Pilot>> classEntry : pilotsByClass.entrySet()) {
+            List<Pilot> classPilots = classEntry.getValue();
+            int minCount = Integer.MAX_VALUE;
+            int maxCount = Integer.MIN_VALUE;
+            for (Pilot p : classPilots) {
+                int c = countByPilotId.get(p.getPrimary_id());
+                if (c < minCount) minCount = c;
+                if (c > maxCount) maxCount = c;
+            }
+            if (minCount != maxCount) {
+                List<Map<String, Object>> pilotsAtMin = new ArrayList<>();
+                List<Map<String, Object>> pilotsAtMax = new ArrayList<>();
+                for (Pilot p : classPilots) {
+                    int c = countByPilotId.get(p.getPrimary_id());
+                    if (c == minCount || c == maxCount) {
+                        Map<String, Object> info = new HashMap<>();
+                        info.put("pilotId", p.getPrimary_id());
+                        info.put("name", p.getName());
+                        if (c == minCount) pilotsAtMin.add(info);
+                        else pilotsAtMax.add(info);
+                    }
+                }
+                Map<String, Object> failure = new HashMap<>();
+                failure.put("className", classEntry.getKey());
+                failure.put("minCount", minCount);
+                failure.put("maxCount", maxCount);
+                failure.put("pilotsAtMin", pilotsAtMin);
+                failure.put("pilotsAtMax", pilotsAtMax);
+                rule2Failures.add(failure);
+            }
+        }
+
+        if (rule1Failures.isEmpty() && rule2Failures.isEmpty()) {
+            return null;
+        }
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("result", "fail");
+        payload.put("blocker", "format_change_unsafe");
+        payload.put("message", "Cannot change to single-sequence — data is not in a clean state");
+        payload.put("rule1Failures", rule1Failures);
+        payload.put("rule2Failures", rule2Failures);
+        return payload;
+    }
+
+    /**
      * Counts the number of distinct rounds the pilot has scored for the
      * given round type.
      */

--- a/judge/src/main/java/co/za/imac/judge/service/SequenceValidationService.java
+++ b/judge/src/main/java/co/za/imac/judge/service/SequenceValidationService.java
@@ -4,6 +4,7 @@ import co.za.imac.judge.dto.Pilot;
 import co.za.imac.judge.dto.ScheduleDTO;
 import co.za.imac.judge.dto.ValidationResult;
 import co.za.imac.judge.dto.ValidationIssue;
+import co.za.imac.judge.utils.ContestClasses;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,11 +34,6 @@ public class SequenceValidationService {
 
     @Autowired
     private CompService compService;
-
-    // Competition class ordering (from RootController)
-    private static final List<String> CLASS_ORDER = Arrays.asList(
-        "BASIC", "SPORTSMAN", "INTERMEDIATE", "ADVANCED", "UNLIMITED", "INVITATIONAL"
-    );
 
     /**
      * Validates all sequence configurations after sync.
@@ -394,13 +390,9 @@ public class SequenceValidationService {
             if ("SYSTEM".equals(a) || "SEQUENCES".equals(a)) return -1;
             if ("SYSTEM".equals(b) || "SEQUENCES".equals(b)) return 1;
 
-            // Get order indices
-            int orderA = CLASS_ORDER.indexOf(classA);
-            int orderB = CLASS_ORDER.indexOf(classB);
-
-            // If not in order list, put at end (before FREESTYLE)
-            if (orderA == -1) orderA = CLASS_ORDER.size();
-            if (orderB == -1) orderB = CLASS_ORDER.size();
+            // Get order indices (orderIndex pushes unknown / FREESTYLE to the end)
+            int orderA = ContestClasses.orderIndex(classA);
+            int orderB = ContestClasses.orderIndex(classB);
 
             // Compare by order
             int classCompare = Integer.compare(orderA, orderB);

--- a/judge/src/main/java/co/za/imac/judge/utils/ContestClasses.java
+++ b/judge/src/main/java/co/za/imac/judge/utils/ContestClasses.java
@@ -1,0 +1,39 @@
+package co.za.imac.judge.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * IMAC contest class ordering. Single source of truth for the order classes
+ * appear in admin UI and detection output.
+ *
+ * <p><b>Migration anchor:</b> when the score server starts returning classes
+ * in a defined order rather than relying on this hardcoded list, change
+ * {@link #ORDER} from a {@code static final} constant to a runtime accessor
+ * (likely backed by {@code CompService}). Every consumer picks up the new
+ * source automatically.
+ *
+ * <p>FREESTYLE is intentionally absent from {@link #ORDER}; it sorts to the
+ * end via {@link #orderIndex(String)} alongside null and unknown values.
+ */
+public final class ContestClasses {
+
+    public static final List<String> ORDER = Arrays.asList(
+        "BASIC", "SPORTSMAN", "INTERMEDIATE", "ADVANCED", "UNLIMITED", "INVITATIONAL"
+    );
+
+    private ContestClasses() {
+    }
+
+    /**
+     * Case-insensitive position lookup. Returns {@code ORDER.size()} for null,
+     * unknown, or FREESTYLE so they sort to the end.
+     */
+    public static int orderIndex(String className) {
+        if (className == null) {
+            return ORDER.size();
+        }
+        int idx = ORDER.indexOf(className.toUpperCase());
+        return idx == -1 ? ORDER.size() : idx;
+    }
+}

--- a/judge/src/main/resources/templates/admin.html
+++ b/judge/src/main/resources/templates/admin.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 20px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.5vw + 2.5vh) !important;
@@ -39,21 +38,21 @@
     .admin-tile {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 18px 20px;
-      margin-bottom: 12px;
+      padding: 12px 16px;
+      margin-bottom: 8px;
       background: #fafafa;
     }
     .admin-tile-link:active .admin-tile {
       background: #eceff1;
     }
     .admin-tile-title {
-      font-size: 1.4rem;
+      font-size: 1.9rem;
       font-weight: 600;
       color: #263238;
       margin-bottom: 4px;
     }
     .admin-tile-text {
-      font-size: 0.95rem;
+      font-size: 1.5rem;
       color: #555;
     }
     .event-line {

--- a/judge/src/main/resources/templates/admin.html
+++ b/judge/src/main/resources/templates/admin.html
@@ -56,6 +56,12 @@
       font-size: 0.95rem;
       color: #555;
     }
+    .event-line {
+      font-size: 1.6rem;
+      font-weight: 700;
+      color: #263238;
+      margin: 0 0 12px;
+    }
   </style>
 </head>
 
@@ -74,6 +80,8 @@
           </a>
         </div>
       </div>
+
+      <p class="event-line" th:text="${compName}"></p>
 
       <a href="/admin/comp" class="admin-tile-link">
         <div class="admin-tile">

--- a/judge/src/main/resources/templates/admin.html
+++ b/judge/src/main/resources/templates/admin.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+  <title>Admin</title>
+
+  <!-- CSS  -->
+  <link href="/materialize/css/material_lcons.css" rel="stylesheet">
+  <link href="/materialize/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection" />
+  <style>
+    .header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      margin-top: 20px;
+      margin-bottom: 8px;
+    }
+    .heading {
+      font-size: calc(1.5vw + 2.5vh) !important;
+      margin: 0;
+    }
+    .nav-buttons {
+      display: flex;
+      gap: 5px;
+      flex-wrap: wrap;
+    }
+    .admin-nav-btn {
+      margin: 2px;
+      padding: 0 12px;
+    }
+    .admin-tile-link {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+    }
+    .admin-tile {
+      border: 2px solid #90a4ae;
+      border-radius: 8px;
+      padding: 18px 20px;
+      margin-bottom: 12px;
+      background: #fafafa;
+    }
+    .admin-tile-link:active .admin-tile {
+      background: #eceff1;
+    }
+    .admin-tile-title {
+      font-size: 1.4rem;
+      font-weight: 600;
+      color: #263238;
+      margin-bottom: 4px;
+    }
+    .admin-tile-text {
+      font-size: 0.95rem;
+      color: #555;
+    }
+  </style>
+</head>
+
+<body class="orange lighten-4">
+  <div th:replace="~{banner::line_judge}"></div>
+  <div th:replace="~{banner::status}"></div>
+
+  <div class="section no-pad-bot orange lighten-4" id="index-banner">
+    <div class="container orange lighten-4 black-text">
+
+      <div class="header-row">
+        <h2 class="heading">Admin</h2>
+        <div class="nav-buttons">
+          <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
+            <i class="material-icons left">exit_to_app</i>Exit
+          </a>
+        </div>
+      </div>
+
+      <a href="/admin/comp" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">Event Admin</div>
+          <div class="admin-tile-text">Set sequence options, Score server actions, and load new events.</div>
+        </div>
+      </a>
+
+      <a href="/admin/scores" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">Score Fixes</div>
+          <div class="admin-tile-text">Resolve score mismatches and per-pilot fixes.</div>
+        </div>
+      </a>
+
+      <a href="/admin/device" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">Device Settings</div>
+          <div class="admin-tile-text">Scoring mode, line/judge numbers, and software updates.</div>
+        </div>
+      </a>
+
+    </div>
+  </div>
+
+  <!--  Scripts-->
+  <script src="/jquery-3.6.4.min.js"></script>
+  <script src="/materialize/js/materialize.js"></script>
+
+</body>
+
+</html>

--- a/judge/src/main/resources/templates/adminComp.html
+++ b/judge/src/main/resources/templates/adminComp.html
@@ -178,6 +178,27 @@
         </div>
       </div>
 
+      <!-- Format-change blocker modal -->
+      <div id="formatChangeBlockerModal" class="modal">
+        <div class="modal-content" style="padding: 15px 20px 10px;">
+          <h5 style="margin-top: 0;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px;">block</i>Cannot Change to Single Sequence</h5>
+          <div id="rule1FailuresWrap" style="display: none; margin-top: 10px;">
+            <div style="font-weight: 500; margin-bottom: 4px;">Pilots mid-round (between sequence 1 and sequence 2):</div>
+            <ul id="rule1FailuresList" style="margin-top: 4px; padding-left: 20px;"></ul>
+          </div>
+          <div id="rule2FailuresWrap" style="display: none; margin-top: 10px;">
+            <div style="font-weight: 500; margin-bottom: 4px;">Classes with uneven KNOWN round counts:</div>
+            <ul id="rule2FailuresList" style="margin-top: 4px; padding-left: 20px;"></ul>
+          </div>
+          <p style="font-size: 0.95rem; color: #444; margin: 12px 0 4px;">
+            Resolve them in Score Fixes first.
+          </p>
+        </div>
+        <div class="modal-footer" style="padding: 10px 20px;">
+          <a href="/admin/scores" class="waves-effect waves-light btn">Go to Score Fixes</a>
+        </div>
+      </div>
+
     </div>
   </div>
 
@@ -217,6 +238,45 @@
       $("input[name=sequenceType][value=" + sequenceType + "]").prop('checked', true);
     });
 
+    function showFormatChangeBlocker(payload) {
+      var $rule1Wrap = $('#rule1FailuresWrap');
+      var $rule1List = $('#rule1FailuresList');
+      $rule1List.empty();
+      var rule1 = payload.rule1Failures || [];
+      if (rule1.length > 0) {
+        rule1.forEach(function (f) {
+          $rule1List.append('<li>' + f.name + ' (' + f.className + ') — KNOWN round ' + f.round + '</li>');
+        });
+        $rule1Wrap.show();
+      } else {
+        $rule1Wrap.hide();
+      }
+
+      var $rule2Wrap = $('#rule2FailuresWrap');
+      var $rule2List = $('#rule2FailuresList');
+      $rule2List.empty();
+      var rule2 = payload.rule2Failures || [];
+      if (rule2.length > 0) {
+        rule2.forEach(function (f) {
+          var atMin = (f.pilotsAtMin || []).map(function (p) { return p.name; }).join(', ');
+          var atMax = (f.pilotsAtMax || []).map(function (p) { return p.name; }).join(', ');
+          $rule2List.append('<li>' + f.className + ': counts span ' + f.minCount + ' (' + atMin + ') to ' + f.maxCount + ' (' + atMax + ')</li>');
+        });
+        $rule2Wrap.show();
+      } else {
+        $rule2Wrap.hide();
+      }
+
+      var modal = M.Modal.getInstance(document.getElementById('formatChangeBlockerModal'));
+      modal.open();
+    }
+
+    function isFormatChangeBlockedResponse(errObj) {
+      return errObj && errObj.status === 409
+          && errObj.responseJSON
+          && errObj.responseJSON.blocker === 'format_change_unsafe';
+    }
+
     // Update Local Settings (no Score contact)
     $("#updateLocalSettings").click(function (e) {
       e.preventDefault();
@@ -239,8 +299,12 @@
             M.toast({ html: 'Error: ' + data.message, classes: 'red' });
           }
         },
-        error: function () {
-          M.toast({ html: 'Error updating settings', classes: 'red' });
+        error: function (errObj) {
+          if (isFormatChangeBlockedResponse(errObj)) {
+            showFormatChangeBlocker(errObj.responseJSON);
+          } else {
+            M.toast({ html: 'Error updating settings', classes: 'red' });
+          }
         }
       });
     });
@@ -273,7 +337,9 @@
           }
         },
         error: function (errObj) {
-          if (typeof errObj.responseJSON != "undefined") {
+          if (isFormatChangeBlockedResponse(errObj)) {
+            showFormatChangeBlocker(errObj.responseJSON);
+          } else if (typeof errObj.responseJSON != "undefined") {
             M.toast({ html: 'Error: ' + errObj.responseJSON.message, classes: 'red' });
           } else {
             M.toast({ html: 'Error refreshing event', classes: 'red' });

--- a/judge/src/main/resources/templates/adminComp.html
+++ b/judge/src/main/resources/templates/adminComp.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
-  <title>Admin - Scorekeeper</title>
+  <title>Event Admin</title>
 
   <!-- CSS  -->
   <link href="/materialize/css/material_lcons.css" rel="stylesheet">
@@ -87,16 +87,13 @@
 
       <!-- Header + Navigation -->
       <div class="header-row">
-        <h2 class="heading">Scorekeeper Admin</h2>
+        <h2 class="heading">Event Admin</h2>
         <div class="nav-buttons">
-          <a href="/admin/device" class="waves-effect waves-light btn blue admin-nav-btn">
-            <i class="material-icons left">devices</i>Device
-          </a>
-          <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
-            <i class="material-icons left">assessment</i>Scores
+          <a href="/admin" class="waves-effect waves-light btn blue-grey admin-nav-btn">
+            <i class="material-icons left">menu</i>Admin Menu
           </a>
           <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
-            <i class="material-icons left">home</i>Home
+            <i class="material-icons left">exit_to_app</i>Exit
           </a>
         </div>
       </div>
@@ -207,7 +204,7 @@
       <i class="large material-icons">menu</i>
     </a>
     <ul>
-      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">home</i></a></li>
+      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">exit_to_app</i></a></li>
     </ul>
   </div>
 

--- a/judge/src/main/resources/templates/adminComp.html
+++ b/judge/src/main/resources/templates/adminComp.html
@@ -177,7 +177,7 @@
       <!-- Format-change blocker modal -->
       <div id="formatChangeBlockerModal" class="modal">
         <div class="modal-content" style="padding: 15px 20px 10px;">
-          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">block</i>Cannot Change to Single Sequence</h5>
+          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">block</i>Cannot Change Sequence Mode</h5>
           <div id="rule1FailuresWrap" style="display: none; margin-top: 10px;">
             <div style="font-weight: 500; margin-bottom: 4px; font-size: 1.75rem;">Pilots mid-round (between sequence 1 and sequence 2):</div>
             <ul id="rule1FailuresList" style="margin-top: 4px; padding-left: 20px; font-size: 1.75rem;"></ul>

--- a/judge/src/main/resources/templates/adminComp.html
+++ b/judge/src/main/resources/templates/adminComp.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 20px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.5vw + 2.5vh) !important;
@@ -34,12 +33,12 @@
     .admin-box {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 10px 15px;
-      margin-bottom: 10px;
+      padding: 10px 14px;
+      margin-bottom: 8px;
       background: #fafafa;
     }
     .admin-box-title {
-      font-size: 1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       margin-bottom: 8px;
       color: #455a64;
@@ -51,7 +50,7 @@
       padding: 4px 0;
     }
     .setting-label {
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       font-weight: 500;
       min-width: 140px;
     }
@@ -61,7 +60,7 @@
     }
     [type="radio"]:not(:checked)+span, [type="radio"]:checked+span {
       padding-left: 25px;
-      font-size: 0.95rem;
+      font-size: 1.75rem;
     }
     .action-buttons {
       display: flex;
@@ -70,7 +69,7 @@
       flex-wrap: wrap;
     }
     .warning-note {
-      font-size: 0.8rem;
+      font-size: 1.5rem;
       color: #c62828;
       margin-top: 5px;
       text-align: center;
@@ -101,7 +100,7 @@
       <!-- Box 1: Local Device Settings -->
       <div class="admin-box">
         <div class="admin-box-title">
-          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.2rem;">tune</i>
+          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.5rem;">tune</i>
           Local Device Settings
         </div>
 
@@ -143,7 +142,7 @@
       <!-- Box 2: Score Server Actions -->
       <div class="admin-box">
         <div class="admin-box-title">
-          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.2rem;">cloud_sync</i>
+          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.5rem;">cloud_sync</i>
           Score Server Actions
         </div>
 
@@ -156,7 +155,7 @@
           </a>
         </div>
         <div class="warning-note">
-          <i class="material-icons" style="vertical-align: middle; font-size: 1rem;">warning</i>
+          <i class="material-icons" style="vertical-align: middle; font-size: 1.5rem;">warning</i>
           Load NEW archives current scores
         </div>
       </div>
@@ -164,8 +163,8 @@
       <!-- Confirmation Modal for New Event -->
       <div id="confirmNewEventModal" class="modal">
         <div class="modal-content" style="padding: 15px 20px 10px;">
-          <h5 style="margin-top: 0;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px;">warning</i>Load NEW Event?</h5>
-          <p style="font-size: 0.95rem; color: #666; margin: 10px 0;">
+          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">warning</i>Load NEW Event?</h5>
+          <p style="font-size: 1.75rem; color: #666; margin: 10px 0;">
             This will archive current scores, clear pilot data, and load fresh data from Score.
           </p>
         </div>
@@ -178,16 +177,16 @@
       <!-- Format-change blocker modal -->
       <div id="formatChangeBlockerModal" class="modal">
         <div class="modal-content" style="padding: 15px 20px 10px;">
-          <h5 style="margin-top: 0;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px;">block</i>Cannot Change to Single Sequence</h5>
+          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">block</i>Cannot Change to Single Sequence</h5>
           <div id="rule1FailuresWrap" style="display: none; margin-top: 10px;">
-            <div style="font-weight: 500; margin-bottom: 4px;">Pilots mid-round (between sequence 1 and sequence 2):</div>
-            <ul id="rule1FailuresList" style="margin-top: 4px; padding-left: 20px;"></ul>
+            <div style="font-weight: 500; margin-bottom: 4px; font-size: 1.75rem;">Pilots mid-round (between sequence 1 and sequence 2):</div>
+            <ul id="rule1FailuresList" style="margin-top: 4px; padding-left: 20px; font-size: 1.75rem;"></ul>
           </div>
           <div id="rule2FailuresWrap" style="display: none; margin-top: 10px;">
-            <div style="font-weight: 500; margin-bottom: 4px;">Classes with uneven KNOWN round counts:</div>
-            <ul id="rule2FailuresList" style="margin-top: 4px; padding-left: 20px;"></ul>
+            <div style="font-weight: 500; margin-bottom: 4px; font-size: 1.75rem;">Classes with uneven KNOWN round counts:</div>
+            <ul id="rule2FailuresList" style="margin-top: 4px; padding-left: 20px; font-size: 1.75rem;"></ul>
           </div>
-          <p style="font-size: 0.95rem; color: #444; margin: 12px 0 4px;">
+          <p style="font-size: 1.5rem; color: #444; margin: 12px 0 4px;">
             Resolve them in Score Fixes first.
           </p>
         </div>

--- a/judge/src/main/resources/templates/adminDevice.html
+++ b/judge/src/main/resources/templates/adminDevice.html
@@ -112,14 +112,11 @@
       <div class="header-row">
         <h2 class="heading">Device Settings</h2>
         <div class="nav-buttons">
-          <a href="/admin/comp" class="waves-effect waves-light btn blue-grey admin-nav-btn">
-            <i class="material-icons left">settings</i>Scorekeeper
-          </a>
-          <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
-            <i class="material-icons left">assessment</i>Scores
+          <a href="/admin" class="waves-effect waves-light btn blue-grey admin-nav-btn">
+            <i class="material-icons left">menu</i>Admin Menu
           </a>
           <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
-            <i class="material-icons left">home</i>Home
+            <i class="material-icons left">exit_to_app</i>Exit
           </a>
         </div>
       </div>
@@ -253,8 +250,7 @@
       <i class="large material-icons">menu</i>
     </a>
     <ul>
-      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">home</i></a></li>
-      <li><a class="btn-floating btn-large blue-grey" href="/admin/comp"><i class="material-icons">settings</i></a></li>
+      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">exit_to_app</i></a></li>
     </ul>
   </div>
 

--- a/judge/src/main/resources/templates/adminDevice.html
+++ b/judge/src/main/resources/templates/adminDevice.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 20px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.5vw + 2.5vh) !important;
@@ -34,12 +33,12 @@
     .admin-box {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 10px 15px;
-      margin-bottom: 10px;
+      padding: 10px 14px;
+      margin-bottom: 8px;
       background: #fafafa;
     }
     .admin-box-title {
-      font-size: 1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       margin-bottom: 8px;
       color: #455a64;
@@ -51,7 +50,7 @@
       padding: 4px 0;
     }
     .setting-label {
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       font-weight: 500;
       min-width: 120px;
     }
@@ -62,7 +61,7 @@
     }
     [type="radio"]:not(:checked)+span, [type="radio"]:checked+span {
       padding-left: 25px;
-      font-size: 0.95rem;
+      font-size: 1.75rem;
     }
     .number-control {
       display: flex;
@@ -86,17 +85,17 @@
       background: #ffebee;
       border: 2px solid #ef5350;
       border-radius: 8px;
-      padding: 10px 15px;
-      margin-bottom: 10px;
+      padding: 10px 14px;
+      margin-bottom: 8px;
     }
     .warning-box-title {
-      font-size: 0.95rem;
+      font-size: 1.9rem;
       font-weight: 600;
       margin-bottom: 4px;
       color: #c62828;
     }
     .warning-text {
-      font-size: 0.8rem;
+      font-size: 1.5rem;
       color: #b71c1c;
     }
   </style>
@@ -124,7 +123,7 @@
       <!-- Box 1: Scoring Mode -->
       <div class="admin-box">
         <div class="admin-box-title">
-          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.2rem;">dashboard</i>
+          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.5rem;">dashboard</i>
           Scoring Mode
         </div>
 
@@ -156,7 +155,7 @@
       <!-- Box 2: Device Identity -->
       <div class="warning-box">
         <div class="warning-box-title">
-          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1rem;">warning</i>
+          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.5rem;">warning</i>
           Device Identity
         </div>
         <div class="warning-text" style="margin-bottom: 6px;">
@@ -191,10 +190,10 @@
       <!-- Box 3: System Update -->
       <div class="admin-box">
         <div class="admin-box-title">
-          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.2rem;">system_update</i>
+          <i class="material-icons" style="vertical-align: middle; margin-right: 6px; font-size: 1.5rem;">system_update</i>
           System Update
         </div>
-        <div id="versionDisplay" style="font-size: 0.9rem; color: #666; margin-bottom: 10px;">
+        <div id="versionDisplay" style="font-size: 1.5rem; color: #666; margin-bottom: 10px;">
           Current version: <span id="currentVersion" style="font-weight: 500;">loading...</span>
         </div>
         <div class="center">
@@ -206,15 +205,15 @@
           <div class="progress" id="updateProgress">
             <div class="indeterminate"></div>
           </div>
-          <div id="updateMessage" style="font-size: 0.9rem; text-align: center; margin-top: 5px;"></div>
+          <div id="updateMessage" style="font-size: 1.5rem; text-align: center; margin-top: 5px;"></div>
         </div>
       </div>
 
       <!-- Confirmation Modal for Device Identity -->
       <div id="confirmDeviceModal" class="modal">
         <div class="modal-content" style="padding: 15px 20px 10px;">
-          <h5 style="margin-top: 0;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px;">warning</i>Change Device Identity?</h5>
-          <p style="font-size: 0.95rem; color: #666; margin: 10px 0;">
+          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons red-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">warning</i>Change Device Identity?</h5>
+          <p style="font-size: 1.75rem; color: #666; margin: 10px 0;">
             This will save new Line/Judge numbers, connect to Score, archive current scores, and load fresh event data.
           </p>
         </div>
@@ -227,11 +226,11 @@
       <!-- Confirmation Modal for System Update -->
       <div id="confirmUpdateModal" class="modal">
         <div class="modal-content" style="padding: 15px 20px 10px;">
-          <h5 style="margin-top: 0;"><i class="material-icons blue-text" style="vertical-align: middle; margin-right: 8px;">cloud_download</i>Install Update?</h5>
-          <p id="updateVersionInfo" style="font-size: 1rem; margin: 10px 0;">
+          <h5 style="margin-top: 0; font-size: 1.9rem;"><i class="material-icons blue-text" style="vertical-align: middle; margin-right: 8px; font-size: 1.5rem;">cloud_download</i>Install Update?</h5>
+          <p id="updateVersionInfo" style="font-size: 1.5rem; margin: 10px 0;">
             <!-- Populated dynamically with version comparison -->
           </p>
-          <p style="font-size: 0.9rem; color: #666; margin: 5px 0;">
+          <p style="font-size: 1.5rem; color: #666; margin: 5px 0;">
             <i class="material-icons tiny orange-text" style="vertical-align: middle;">warning</i>
             You must be connected to the internet. The device will restart after updating.
           </p>

--- a/judge/src/main/resources/templates/adminScores.html
+++ b/judge/src/main/resources/templates/adminScores.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
-  <title>Admin - Scores</title>
+  <title>Score Fixes</title>
 
   <!-- CSS  -->
   <link href="/materialize/css/material_lcons.css" rel="stylesheet">
@@ -75,16 +75,13 @@
 
       <!-- Header + Navigation -->
       <div class="header-row">
-        <h2 class="heading">Score Admin</h2>
+        <h2 class="heading">Score Fixes</h2>
         <div class="nav-buttons">
-          <a href="/admin/comp" class="waves-effect waves-light btn blue-grey admin-nav-btn">
-            <i class="material-icons left">settings</i>Scorekeeper
-          </a>
-          <a href="/admin/device" class="waves-effect waves-light btn blue admin-nav-btn">
-            <i class="material-icons left">devices</i>Device
+          <a href="/admin" class="waves-effect waves-light btn blue-grey admin-nav-btn">
+            <i class="material-icons left">menu</i>Admin Menu
           </a>
           <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
-            <i class="material-icons left">home</i>Home
+            <i class="material-icons left">exit_to_app</i>Exit
           </a>
         </div>
       </div>
@@ -154,8 +151,7 @@
       <i class="large material-icons">menu</i>
     </a>
     <ul>
-      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">home</i></a></li>
-      <li><a class="btn-floating btn-large blue-grey" href="/admin/comp"><i class="material-icons">settings</i></a></li>
+      <li><a class="btn-floating btn-large green" href="/"><i class="material-icons">exit_to_app</i></a></li>
     </ul>
   </div>
 

--- a/judge/src/main/resources/templates/adminScores.html
+++ b/judge/src/main/resources/templates/adminScores.html
@@ -102,15 +102,15 @@
         </div>
 
         <div class="col s12 m6">
-          <div class="admin-box tool-box disabled-tool">
-            <i class="material-icons tool-icon grey-text">exposure_zero</i>
+          <div class="admin-box tool-box">
+            <i class="material-icons tool-icon orange-text">exposure_zero</i>
             <div class="tool-title">Zero Unflown Rounds</div>
             <div class="tool-text">
-              Mark rounds as zeros for pilots who didn't fly.
+              Mark rounds as zeros for pilots who had to miss a round.
             </div>
-            <span class="btn grey lighten-1" style="margin-top: 10px;">
-              <i class="material-icons left">schedule</i>Coming Soon
-            </span>
+            <a href="/admin/scores/zero-fill" class="waves-effect waves-light btn orange darken-1" style="margin-top: 10px;">
+              <i class="material-icons left">build</i>Open Tool
+            </a>
           </div>
         </div>
       </div>

--- a/judge/src/main/resources/templates/adminScores.html
+++ b/judge/src/main/resources/templates/adminScores.html
@@ -103,6 +103,21 @@
 
         <div class="col s12 m6">
           <div class="admin-box tool-box">
+            <i class="material-icons tool-icon blue-text">swap_horiz</i>
+            <div class="tool-title">Swap Round Scores</div>
+            <div class="tool-text">
+              Swap two pilots' scores for a single round when the judge attributed each pilot's flight to the other.
+            </div>
+            <a href="/admin/scores/swap" class="waves-effect waves-light btn blue darken-1" style="margin-top: 10px;">
+              <i class="material-icons left">build</i>Open Tool
+            </a>
+          </div>
+        </div>
+      </div>
+
+      <div class="row">
+        <div class="col s12 m6">
+          <div class="admin-box tool-box">
             <i class="material-icons tool-icon orange-text">exposure_zero</i>
             <div class="tool-title">Zero Unflown Rounds</div>
             <div class="tool-text">
@@ -113,9 +128,7 @@
             </a>
           </div>
         </div>
-      </div>
 
-      <div class="row">
         <div class="col s12 m6">
           <div class="admin-box tool-box disabled-tool">
             <i class="material-icons tool-icon grey-text">edit</i>

--- a/judge/src/main/resources/templates/adminScores.html
+++ b/judge/src/main/resources/templates/adminScores.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 20px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.5vw + 2.5vh) !important;

--- a/judge/src/main/resources/templates/adminScores.html
+++ b/judge/src/main/resources/templates/adminScores.html
@@ -30,37 +30,42 @@
       margin: 2px;
       padding: 0 12px;
     }
-    .admin-box {
+    .admin-tile-link {
+      display: block;
+      text-decoration: none;
+      color: inherit;
+    }
+    .admin-tile {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 15px;
-      margin-bottom: 10px;
-      background: #fafafa;
-      text-align: center;
-    }
-    .tool-box {
-      min-height: 180px;
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-    }
-    .tool-icon {
-      font-size: 2.5rem;
+      padding: 12px 16px;
       margin-bottom: 8px;
+      background: #fafafa;
     }
-    .tool-title {
-      font-size: 1.1rem;
+    .admin-tile-link:active .admin-tile {
+      background: #eceff1;
+    }
+    .admin-tile-title {
+      font-size: 1.9rem;
       font-weight: 600;
-      margin-bottom: 6px;
+      color: #263238;
+      margin-bottom: 4px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
     }
-    .tool-text {
-      font-size: 0.85rem;
+    .admin-tile-title i.material-icons {
+      font-size: 1.9rem;
+    }
+    .admin-tile-text {
+      font-size: 1.5rem;
       color: #555;
-      max-width: 250px;
     }
-    .disabled-tool {
+    .admin-tile.disabled-tool {
       opacity: 0.6;
+    }
+    .admin-tile.disabled-tool .admin-tile-text .coming-soon {
+      font-style: italic;
     }
   </style>
 </head>
@@ -85,73 +90,45 @@
         </div>
       </div>
 
-      <!-- Score Tools -->
-      <div class="row">
-        <div class="col s12 m6">
-          <div class="admin-box tool-box">
-            <i class="material-icons tool-icon green-text">swap_horiz</i>
-            <div class="tool-title">Resolve Mismatches</div>
-            <div class="tool-text">
-              Move rounds between pilots when scores were recorded to the wrong pilot.
-            </div>
-            <a href="/admin/scores/resolve" class="waves-effect waves-light btn green darken-1" style="margin-top: 10px;">
-              <i class="material-icons left">build</i>Open Tool
-            </a>
+      <a href="/admin/scores/resolve" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">
+            <i class="material-icons green-text">swap_horiz</i>Resolve Mismatches
+          </div>
+          <div class="admin-tile-text">
+            Move rounds between pilots when scores were recorded to the wrong pilot.
           </div>
         </div>
+      </a>
 
-        <div class="col s12 m6">
-          <div class="admin-box tool-box">
-            <i class="material-icons tool-icon blue-text">swap_horiz</i>
-            <div class="tool-title">Swap Round Scores</div>
-            <div class="tool-text">
-              Swap two pilots' scores for a single round when the judge attributed each pilot's flight to the other.
-            </div>
-            <a href="/admin/scores/swap" class="waves-effect waves-light btn blue darken-1" style="margin-top: 10px;">
-              <i class="material-icons left">build</i>Open Tool
-            </a>
+      <a href="/admin/scores/swap" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">
+            <i class="material-icons blue-text">swap_horiz</i>Swap Round Scores
+          </div>
+          <div class="admin-tile-text">
+            Swap two pilots' scores for a single round when the judge attributed each pilot's flight to the other.
           </div>
         </div>
-      </div>
+      </a>
 
-      <div class="row">
-        <div class="col s12 m6">
-          <div class="admin-box tool-box">
-            <i class="material-icons tool-icon orange-text">exposure_zero</i>
-            <div class="tool-title">Zero Unflown Rounds</div>
-            <div class="tool-text">
-              Mark rounds as zeros for pilots who had to miss a round.
-            </div>
-            <a href="/admin/scores/zero-fill" class="waves-effect waves-light btn orange darken-1" style="margin-top: 10px;">
-              <i class="material-icons left">build</i>Open Tool
-            </a>
+      <a href="/admin/scores/zero-fill" class="admin-tile-link">
+        <div class="admin-tile">
+          <div class="admin-tile-title">
+            <i class="material-icons orange-text">exposure_zero</i>Zero Unflown Rounds
+          </div>
+          <div class="admin-tile-text">
+            Mark rounds as zeros for pilots who had to miss a round.
           </div>
         </div>
+      </a>
 
-        <div class="col s12 m6">
-          <div class="admin-box tool-box disabled-tool">
-            <i class="material-icons tool-icon grey-text">edit</i>
-            <div class="tool-title">Edit Scores</div>
-            <div class="tool-text">
-              Manually edit individual figure scores.
-            </div>
-            <span class="btn grey lighten-1" style="margin-top: 10px;">
-              <i class="material-icons left">schedule</i>Coming Soon
-            </span>
-          </div>
+      <div class="admin-tile disabled-tool">
+        <div class="admin-tile-title">
+          <i class="material-icons grey-text">history</i>Audit Log
         </div>
-
-        <div class="col s12 m6">
-          <div class="admin-box tool-box disabled-tool">
-            <i class="material-icons tool-icon grey-text">history</i>
-            <div class="tool-title">Audit Log</div>
-            <div class="tool-text">
-              View history of score changes and corrections.
-            </div>
-            <span class="btn grey lighten-1" style="margin-top: 10px;">
-              <i class="material-icons left">schedule</i>Coming Soon
-            </span>
-          </div>
+        <div class="admin-tile-text">
+          <span class="coming-soon">Coming soon — view history of score changes and corrections.</span>
         </div>
       </div>
 

--- a/judge/src/main/resources/templates/adminScoresResolve.html
+++ b/judge/src/main/resources/templates/adminScoresResolve.html
@@ -205,10 +205,10 @@
         <h2 class="heading">Resolve Score Mismatches</h2>
         <div class="nav-buttons">
           <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
-            <i class="material-icons left">arrow_back</i>Back
+            <i class="material-icons left">arrow_back</i>Score Fixes
           </a>
           <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
-            <i class="material-icons left">home</i>Home
+            <i class="material-icons left">exit_to_app</i>Exit
           </a>
         </div>
       </div>
@@ -231,7 +231,7 @@
         <div style="font-size: 1.2rem; font-weight: 500;">All scores look good!</div>
         <div style="margin-top: 5px;">No round count mismatches detected.</div>
         <a href="/admin/scores" class="waves-effect waves-light btn green" style="margin-top: 20px;">
-          <i class="material-icons left">arrow_back</i>Back to Score Admin
+          <i class="material-icons left">arrow_back</i>Back to Score Fixes
         </a>
       </div>
 

--- a/judge/src/main/resources/templates/adminScoresResolve.html
+++ b/judge/src/main/resources/templates/adminScoresResolve.html
@@ -196,15 +196,22 @@
     .manual-class-row {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       gap: 8px;
-      padding: 6px 0;
+      padding: 8px 14px;
+      margin-bottom: 6px;
+      border: 1px solid #90a4ae;
+      border-radius: 6px;
     }
     .manual-class-label {
-      flex: 0 0 130px;
       font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
+    }
+    .manual-class-btns {
+      display: flex;
+      gap: 8px;
     }
     .manual-type-btn {
       padding: 8px 14px;
@@ -565,6 +572,7 @@
         const groups = byClass[className];
         const $row = $('<div class="manual-class-row">');
         $row.append($('<div class="manual-class-label">').text(className));
+        const $btns = $('<div class="manual-class-btns">');
         ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
           const g = groups.find(function (x) { return x.roundType === rt; });
           if (!g) return;
@@ -579,14 +587,16 @@
             showStep('step-op-choice');
             renderStep1();
           });
-          $row.append($btn);
+          $btns.append($btn);
         });
+        $row.append($btns);
         $rows.append($row);
       });
 
       if (freestyle) {
-        $rows.append($('<div class="manual-divider">'));
-        const $fsRow = $('<div class="manual-freestyle-row">');
+        const $row = $('<div class="manual-class-row">');
+        $row.append($('<div class="manual-class-label">').text('FREESTYLE'));
+        const $btns = $('<div class="manual-class-btns">');
         const $btn = $('<a href="#" class="manual-type-btn">').text('Freestyle');
         $btn.on('click', function (e) {
           e.preventDefault();
@@ -598,8 +608,9 @@
           showStep('step-op-choice');
           renderStep1();
         });
-        $fsRow.append($btn);
-        $rows.append($fsRow);
+        $btns.append($btn);
+        $row.append($btns);
+        $rows.append($row);
       }
     }
 

--- a/judge/src/main/resources/templates/adminScoresResolve.html
+++ b/judge/src/main/resources/templates/adminScoresResolve.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 10px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.2vw + 2vh) !important;
@@ -32,16 +31,16 @@
       padding: 0 12px;
     }
     .wizard-context {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 500;
       color: #455a64;
-      margin: 4px 0 12px;
+      margin: 4px 0 8px;
     }
     .mismatch-card {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 12px 14px;
-      margin-bottom: 10px;
+      padding: 10px 14px;
+      margin-bottom: 8px;
       background: #fafafa;
       cursor: pointer;
     }
@@ -49,32 +48,32 @@
       background: #eceff1;
     }
     .mismatch-card-title {
-      font-size: 1.2rem;
+      font-size: 1.9rem;
       font-weight: 600;
       color: #263238;
       margin-bottom: 4px;
     }
     .mismatch-card-line {
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       color: #555;
     }
     .force-edits-btn-wrap {
-      margin-top: 16px;
+      margin: 12px auto 6px auto;
       text-align: center;
     }
     .all-clear {
       text-align: center;
-      padding: 16px;
+      padding: 16px 10px;
       color: #2e7d32;
     }
     .all-clear i {
       font-size: 3.5rem;
       color: #4caf50;
       display: block;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
     }
     .all-clear-title {
-      font-size: 1.2rem;
+      font-size: 2.1rem;
       font-weight: 500;
     }
     .loading-spinner {
@@ -84,8 +83,8 @@
     .pilot-context-row {
       display: flex;
       justify-content: space-between;
-      padding: 6px 12px;
-      font-size: 1.2rem;
+      padding: 4px 0;
+      font-size: 1.75rem;
     }
     .pilot-context-row.is-mismatch {
       color: #c62828;
@@ -94,17 +93,18 @@
     .op-buttons {
       display: flex;
       flex-direction: row;
-      gap: 8px;
-      margin: 10px 0;
+      gap: 10px;
+      margin-top: 6px;
     }
     .op-btn {
       flex: 1;
-      padding: 14px 8px;
+      min-height: 60px;
+      padding: 6px 12px;
       border-radius: 8px;
       border: 2px solid #1976d2;
       background: #e3f2fd;
       color: #0d47a1;
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 600;
       text-align: center;
       cursor: pointer;
@@ -121,19 +121,20 @@
       cursor: default;
     }
     .step1-caption {
-      font-size: 0.95rem;
+      font-size: 1.5rem;
       color: #555;
-      margin: 8px 0 12px;
+      margin-top: 10px;
       line-height: 1.4;
     }
     .step1-caption strong {
       color: #263238;
     }
     .nothing-actionable {
-      font-size: 0.95rem;
+      font-size: 1.5rem;
       color: #c62828;
       text-align: center;
-      margin: 8px 0;
+      padding: 6px 12px;
+      margin-top: 6px;
     }
     .pick-row {
       display: block;
@@ -142,7 +143,7 @@
       border: 2px solid #90a4ae;
       border-radius: 8px;
       background: #fafafa;
-      font-size: 1rem;
+      font-size: 1.75rem;
       color: #263238;
       cursor: pointer;
       text-decoration: none;
@@ -154,19 +155,20 @@
       font-weight: 500;
     }
     .pick-row .row-meta {
-      font-size: 0.9rem;
+      font-size: 1.5rem;
       color: #555;
     }
     .pick-row.disabled {
       background: #e0e0e0;
       color: #757575;
       border-color: #bdbdbd;
-      cursor: default;
+      cursor: not-allowed;
     }
     .pick-row.disabled .row-meta,
     .pick-row .row-caption {
       color: #616161;
-      font-size: 0.85rem;
+      font-size: 1.5rem;
+      margin-top: 3px;
     }
     .round-pick-row {
       display: block;
@@ -176,7 +178,7 @@
       border-radius: 8px;
       background: #e3f2fd;
       color: #0d47a1;
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       text-align: center;
       cursor: pointer;
@@ -186,10 +188,10 @@
       background: #bbdefb;
     }
     .step-section-title {
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       color: #455a64;
-      margin: 10px 0 8px;
+      margin: 8px 0 6px 0;
     }
     .manual-class-row {
       display: flex;
@@ -198,18 +200,19 @@
       padding: 6px 0;
     }
     .manual-class-label {
-      flex: 0 0 110px;
+      flex: 0 0 130px;
+      font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
     }
     .manual-type-btn {
-      padding: 6px 14px;
+      padding: 8px 14px;
       border: 2px solid #90a4ae;
       border-radius: 6px;
       background: #fafafa;
       color: #263238;
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       cursor: pointer;
       text-decoration: none;
     }
@@ -227,35 +230,35 @@
     .confirm-box {
       border: 2px solid #1976d2;
       border-radius: 8px;
-      padding: 12px 16px;
+      padding: 10px 14px;
       background: #e3f2fd;
       color: #0d47a1;
-      margin: 10px 0;
+      margin-bottom: 10px;
     }
     .confirm-line {
-      font-size: 1rem;
+      font-size: 1.75rem;
       margin: 4px 0;
     }
     .confirm-action {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 600;
       margin-bottom: 8px;
     }
     .confirm-after-title {
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       font-weight: 500;
       margin-top: 8px;
     }
     .confirm-buttons {
       display: flex;
-      gap: 12px;
+      gap: 10px;
       justify-content: center;
-      margin-top: 12px;
+      margin-top: 8px;
     }
     .result-box {
       text-align: center;
-      padding: 18px;
-      margin: 14px 0;
+      padding: 12px 16px;
+      margin: 10px 0;
       border-radius: 8px;
       background: #e8f5e9;
       color: #1b5e20;
@@ -264,7 +267,7 @@
       font-size: 3rem;
     }
     .result-message {
-      font-size: 1.2rem;
+      font-size: 1.75rem;
       font-weight: 500;
       margin: 8px 0;
     }

--- a/judge/src/main/resources/templates/adminScoresResolve.html
+++ b/judge/src/main/resources/templates/adminScoresResolve.html
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
-  <title>Admin - Resolve Score Mismatches</title>
+  <title>Resolve Score Mismatches</title>
 
   <!-- CSS  -->
   <link href="/materialize/css/material_lcons.css" rel="stylesheet">
@@ -15,7 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 20px;
+      margin-top: 10px;
       margin-bottom: 8px;
     }
     .heading {
@@ -31,164 +31,247 @@
       margin: 2px;
       padding: 0 12px;
     }
+    .wizard-context {
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: #455a64;
+      margin: 4px 0 12px;
+    }
     .mismatch-card {
       border: 2px solid #90a4ae;
       border-radius: 8px;
-      padding: 15px;
-      margin-bottom: 15px;
-      background: #fafafa;
-    }
-    .mismatch-header {
-      font-size: 1.1rem;
-      font-weight: 600;
-      color: #455a64;
+      padding: 12px 14px;
       margin-bottom: 10px;
-      display: flex;
-      align-items: center;
+      background: #fafafa;
+      cursor: pointer;
     }
-    .mismatch-header i {
-      margin-right: 8px;
-      color: #ff9800;
+    .mismatch-card:active {
+      background: #eceff1;
     }
-    .expected-badge {
-      background: #e3f2fd;
-      padding: 2px 10px;
-      border-radius: 12px;
-      font-size: 0.85rem;
-      margin-left: 10px;
+    .mismatch-card-title {
+      font-size: 1.2rem;
+      font-weight: 600;
+      color: #263238;
+      margin-bottom: 4px;
     }
-    .pilot-group {
-      margin: 10px 0;
+    .mismatch-card-line {
+      font-size: 0.95rem;
+      color: #555;
     }
-    .pilot-group-title {
-      font-size: 0.9rem;
-      font-weight: 500;
-      color: #666;
-      margin-bottom: 5px;
+    .force-edits-btn-wrap {
+      margin-top: 16px;
+      text-align: center;
     }
-    .pilot-row {
-      display: flex;
-      align-items: center;
-      padding: 8px 12px;
-      background: #fff;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      margin-bottom: 5px;
-    }
-    .pilot-row.too-many {
-      border-left: 4px solid #4caf50;
-    }
-    .pilot-row.too-few {
-      border-left: 4px solid #f44336;
-    }
-    .pilot-row label {
-      flex: 1;
-      margin: 0;
-    }
-    .pilot-name {
-      font-weight: 500;
-    }
-    .pilot-rounds {
-      font-size: 0.9rem;
-      color: #666;
-    }
-    .round-badge {
-      padding: 2px 8px;
-      border-radius: 10px;
-      font-size: 0.8rem;
-      font-weight: 500;
-    }
-    .round-badge.plus {
-      background: #c8e6c9;
+    .all-clear {
+      text-align: center;
+      padding: 16px;
       color: #2e7d32;
     }
-    .round-badge.minus {
-      background: #ffcdd2;
-      color: #c62828;
-    }
-    .resolve-btn {
-      margin-top: 10px;
-    }
-    .no-mismatches {
-      text-align: center;
-      padding: 40px;
-      color: #666;
-    }
-    .no-mismatches i {
-      font-size: 4rem;
+    .all-clear i {
+      font-size: 3.5rem;
       color: #4caf50;
       display: block;
-      margin-bottom: 15px;
-    }
-    /* Resolve Modal */
-    .resolve-modal {
-      max-width: 600px;
-    }
-    .modal-pilot-header {
-      display: flex;
-      justify-content: space-between;
-      margin-bottom: 15px;
-    }
-    .modal-pilot-box {
-      flex: 1;
-      padding: 10px;
-      border-radius: 8px;
-      text-align: center;
-    }
-    .modal-pilot-box.source {
-      background: #e8f5e9;
-      margin-right: 10px;
-    }
-    .modal-pilot-box.dest {
-      background: #ffebee;
-    }
-    .modal-pilot-name {
-      font-weight: 600;
-      font-size: 1rem;
-    }
-    .modal-pilot-rounds {
-      font-size: 0.85rem;
-      color: #666;
-    }
-    .round-select-title {
-      font-weight: 500;
-      margin: 15px 0 10px 0;
-    }
-    .round-option {
-      padding: 10px 15px;
-      border: 1px solid #ddd;
-      border-radius: 4px;
       margin-bottom: 8px;
-      background: #fff;
     }
-    .round-option:hover {
-      background: #f5f5f5;
-    }
-    .preview-box {
-      background: #fff3e0;
-      border: 1px solid #ffcc80;
-      border-radius: 8px;
-      padding: 15px;
-      margin-top: 15px;
-      display: none;
-    }
-    .preview-title {
-      font-weight: 600;
-      margin-bottom: 10px;
-      color: #e65100;
-    }
-    .preview-item {
-      font-size: 0.9rem;
-      padding: 3px 0;
-    }
-    .preview-item i {
-      font-size: 1rem;
-      vertical-align: middle;
-      margin-right: 5px;
+    .all-clear-title {
+      font-size: 1.2rem;
+      font-weight: 500;
     }
     .loading-spinner {
       text-align: center;
-      padding: 40px;
+      padding: 20px;
+    }
+    .pilot-context-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 6px 12px;
+      font-size: 1.2rem;
+    }
+    .pilot-context-row.is-mismatch {
+      color: #c62828;
+      font-weight: 500;
+    }
+    .op-buttons {
+      display: flex;
+      flex-direction: row;
+      gap: 8px;
+      margin: 10px 0;
+    }
+    .op-btn {
+      flex: 1;
+      padding: 14px 8px;
+      border-radius: 8px;
+      border: 2px solid #1976d2;
+      background: #e3f2fd;
+      color: #0d47a1;
+      font-size: 1.1rem;
+      font-weight: 600;
+      text-align: center;
+      cursor: pointer;
+      white-space: normal;
+      word-wrap: break-word;
+    }
+    .op-btn:active {
+      background: #bbdefb;
+    }
+    .op-btn.disabled {
+      background: #e0e0e0;
+      color: #757575;
+      border-color: #bdbdbd;
+      cursor: default;
+    }
+    .step1-caption {
+      font-size: 0.95rem;
+      color: #555;
+      margin: 8px 0 12px;
+      line-height: 1.4;
+    }
+    .step1-caption strong {
+      color: #263238;
+    }
+    .nothing-actionable {
+      font-size: 0.95rem;
+      color: #c62828;
+      text-align: center;
+      margin: 8px 0;
+    }
+    .pick-row {
+      display: block;
+      padding: 10px 14px;
+      margin-bottom: 6px;
+      border: 2px solid #90a4ae;
+      border-radius: 8px;
+      background: #fafafa;
+      font-size: 1rem;
+      color: #263238;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .pick-row:active {
+      background: #eceff1;
+    }
+    .pick-row .row-name {
+      font-weight: 500;
+    }
+    .pick-row .row-meta {
+      font-size: 0.9rem;
+      color: #555;
+    }
+    .pick-row.disabled {
+      background: #e0e0e0;
+      color: #757575;
+      border-color: #bdbdbd;
+      cursor: default;
+    }
+    .pick-row.disabled .row-meta,
+    .pick-row .row-caption {
+      color: #616161;
+      font-size: 0.85rem;
+    }
+    .round-pick-row {
+      display: block;
+      padding: 12px 16px;
+      margin-bottom: 6px;
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      font-size: 1.1rem;
+      font-weight: 600;
+      text-align: center;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .round-pick-row:active {
+      background: #bbdefb;
+    }
+    .step-section-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #455a64;
+      margin: 10px 0 8px;
+    }
+    .manual-class-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+    }
+    .manual-class-label {
+      flex: 0 0 110px;
+      font-weight: 600;
+      text-transform: uppercase;
+      color: #263238;
+    }
+    .manual-type-btn {
+      padding: 6px 14px;
+      border: 2px solid #90a4ae;
+      border-radius: 6px;
+      background: #fafafa;
+      color: #263238;
+      font-size: 0.95rem;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .manual-type-btn:active {
+      background: #eceff1;
+    }
+    .manual-divider {
+      border-top: 1px solid #cfd8dc;
+      margin: 10px 0 8px;
+    }
+    .manual-freestyle-row {
+      text-align: center;
+      margin-top: 8px;
+    }
+    .confirm-box {
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      padding: 12px 16px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      margin: 10px 0;
+    }
+    .confirm-line {
+      font-size: 1rem;
+      margin: 4px 0;
+    }
+    .confirm-action {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    .confirm-after-title {
+      font-size: 0.95rem;
+      font-weight: 500;
+      margin-top: 8px;
+    }
+    .confirm-buttons {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      margin-top: 12px;
+    }
+    .result-box {
+      text-align: center;
+      padding: 18px;
+      margin: 14px 0;
+      border-radius: 8px;
+      background: #e8f5e9;
+      color: #1b5e20;
+    }
+    .result-icon {
+      font-size: 3rem;
+    }
+    .result-message {
+      font-size: 1.2rem;
+      font-weight: 500;
+      margin: 8px 0;
+    }
+    .pilot-list-scroll {
+      max-height: 60vh;
+      overflow-y: auto;
+      padding-right: 4px;
     }
   </style>
 </head>
@@ -200,10 +283,12 @@
   <div class="section no-pad-bot orange lighten-4" id="index-banner">
     <div class="container orange lighten-4 black-text">
 
-      <!-- Header + Navigation -->
       <div class="header-row">
         <h2 class="heading">Resolve Score Mismatches</h2>
         <div class="nav-buttons">
+          <a href="#" id="wizardBackBtn" class="waves-effect waves-light btn blue-grey admin-nav-btn" style="display:none;">
+            <i class="material-icons left">arrow_back</i>Back
+          </a>
           <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
             <i class="material-icons left">arrow_back</i>Score Fixes
           </a>
@@ -213,68 +298,103 @@
         </div>
       </div>
 
-      <!-- Loading State -->
-      <div id="loadingState" class="loading-spinner">
-        <div class="preloader-wrapper big active">
-          <div class="spinner-layer spinner-blue-only">
-            <div class="circle-clipper left"><div class="circle"></div></div>
-            <div class="gap-patch"><div class="circle"></div></div>
-            <div class="circle-clipper right"><div class="circle"></div></div>
+      <div id="wizardContext" class="wizard-context" style="display:none;"></div>
+
+      <!-- Step: Landing (detected mismatch cards + Force Round Edits) -->
+      <div class="wizard-step" id="step-landing">
+        <div id="loadingState" class="loading-spinner">
+          <div class="preloader-wrapper big active">
+            <div class="spinner-layer spinner-blue-only">
+              <div class="circle-clipper left"><div class="circle"></div></div>
+              <div class="gap-patch"><div class="circle"></div></div>
+              <div class="circle-clipper right"><div class="circle"></div></div>
+            </div>
           </div>
+          <p>Scanning for mismatches...</p>
         </div>
-        <p>Scanning for mismatches...</p>
-      </div>
 
-      <!-- No Mismatches State -->
-      <div id="noMismatches" class="no-mismatches" style="display: none;">
-        <i class="material-icons">check_circle</i>
-        <div style="font-size: 1.2rem; font-weight: 500;">All scores look good!</div>
-        <div style="margin-top: 5px;">No round count mismatches detected.</div>
-        <a href="/admin/scores" class="waves-effect waves-light btn green" style="margin-top: 20px;">
-          <i class="material-icons left">arrow_back</i>Back to Score Fixes
-        </a>
-      </div>
-
-      <!-- Mismatches Container -->
-      <div id="mismatchesContainer"></div>
-
-    </div>
-  </div>
-
-  <!-- Resolve Modal -->
-  <div id="resolveModal" class="modal resolve-modal">
-    <div class="modal-content">
-      <h5 style="margin-top: 0;">
-        <i class="material-icons orange-text" style="vertical-align: middle; margin-right: 8px;">swap_horiz</i>
-        Move Round
-      </h5>
-
-      <div class="modal-pilot-header">
-        <div class="modal-pilot-box source">
-          <div style="font-size: 0.8rem; color: #388e3c;">Source (too many)</div>
-          <div class="modal-pilot-name" id="modalSourceName">-</div>
-          <div class="modal-pilot-rounds" id="modalSourceRounds">-</div>
+        <div id="noMismatches" class="all-clear" style="display:none;">
+          <i class="material-icons">check_circle</i>
+          <div class="all-clear-title">All scores look good!</div>
+          <div>No round count mismatches detected.</div>
         </div>
-        <div class="modal-pilot-box dest">
-          <div style="font-size: 0.8rem; color: #c62828;">Destination (too few)</div>
-          <div class="modal-pilot-name" id="modalDestName">-</div>
-          <div class="modal-pilot-rounds" id="modalDestRounds">-</div>
+
+        <div id="mismatchesContainer"></div>
+
+        <div class="force-edits-btn-wrap">
+          <a href="#" id="forceRoundEditsBtn" class="waves-effect waves-light btn blue-grey">
+            <i class="material-icons left">build</i>Force Round Edits
+          </a>
         </div>
       </div>
 
-      <div class="round-select-title">Which round on source pilot belongs to destination?</div>
-      <div id="roundOptions"></div>
-
-      <div class="preview-box" id="previewBox">
-        <div class="preview-title">Preview Changes:</div>
-        <div id="previewContent"></div>
+      <!-- Step: Manual picker (class/type) -->
+      <div class="wizard-step" id="step-manual-picker" style="display:none;">
+        <div class="step-section-title">Pick a class and round type:</div>
+        <div id="manualPickerRows"></div>
       </div>
-    </div>
-    <div class="modal-footer">
-      <a href="#!" class="modal-close waves-effect waves-red btn-flat">Cancel</a>
-      <a href="#!" id="confirmMoveBtn" class="waves-effect waves-light btn green disabled">
-        <i class="material-icons left">check</i>Confirm Move
-      </a>
+
+      <!-- Step 1: operation choice -->
+      <div class="wizard-step" id="step-op-choice" style="display:none;">
+        <div class="op-buttons">
+          <a href="#" id="opFixBtn" class="op-btn">Fix Missing Sequence</a>
+          <a href="#" id="opMoveBtn" class="op-btn">Move Round</a>
+        </div>
+        <p class="step1-caption">
+          <strong>Fix Missing Sequence</strong> = pilot didn't fly seq 2.<br>
+          <strong>Move Round</strong> = wrong pilot was scored.<br>
+          If the pilot legitimately missed a whole round, use the <strong>Zero Unflown Rounds</strong> tile from /admin/scores instead.
+        </p>
+        <div id="step1NothingActionable" class="nothing-actionable" style="display:none;">
+          No actionable items found - buttons disabled
+        </div>
+        <div id="step1PilotContext" class="pilot-list-scroll"></div>
+      </div>
+
+      <!-- Step 2-Fix: pilot pick -->
+      <div class="wizard-step" id="step-fix-pick" style="display:none;">
+        <div class="step-section-title">Pick pilot to fix:</div>
+        <div id="fixPilotList"></div>
+      </div>
+
+      <!-- Step 2a-Move: source -->
+      <div class="wizard-step" id="step-move-source" style="display:none;">
+        <div class="step-section-title">Move FROM:</div>
+        <div id="moveSourceList"></div>
+      </div>
+
+      <!-- Step 2b-Move: dest -->
+      <div class="wizard-step" id="step-move-dest" style="display:none;">
+        <div class="step-section-title">Move TO:</div>
+        <div id="moveDestList"></div>
+      </div>
+
+      <!-- Step 2c-Move: round pick -->
+      <div class="wizard-step" id="step-move-round" style="display:none;">
+        <div id="moveRoundTitle" class="step-section-title"></div>
+        <div id="moveRoundList"></div>
+      </div>
+
+      <!-- Step 3: Confirm -->
+      <div class="wizard-step" id="step-confirm" style="display:none;">
+        <div class="confirm-box" id="confirmBox"></div>
+        <div class="confirm-buttons">
+          <a href="#" id="confirmCancelBtn" class="waves-effect waves-light btn-flat">Cancel</a>
+          <a href="#" id="confirmActionBtn" class="waves-effect waves-light btn green">Confirm</a>
+        </div>
+      </div>
+
+      <!-- Step 4: Result -->
+      <div class="wizard-step" id="step-result" style="display:none;">
+        <div class="result-box">
+          <i class="material-icons result-icon">check_circle</i>
+          <div class="result-message" id="resultMessage"></div>
+        </div>
+        <div class="confirm-buttons">
+          <a href="#" id="resultDoneBtn" class="waves-effect waves-light btn green">Done</a>
+        </div>
+      </div>
+
     </div>
   </div>
 
@@ -282,211 +402,482 @@
   <script src="/jquery-3.6.4.min.js"></script>
   <script src="/materialize/js/materialize.js"></script>
   <script>
-    let currentMismatch = null;
-    let selectedRound = null;
+    /* Resolver wizard — single-page state machine. */
+    const state = {
+      entry: null,           // 'detected' or 'manual'
+      group: null,           // selected (class, roundType) group object from API
+      operation: null,       // 'fix' or 'move'
+      sourcePilot: null,     // for Move
+      destPilot: null,       // for Move
+      sourceRound: null,     // for Move
+      targetPilot: null,     // for Fix
+      allGroups: [],
+      mismatches: []
+    };
+    const stepHistory = [];
 
-    document.addEventListener('DOMContentLoaded', function() {
-      // Initialize modals
-      M.Modal.init(document.querySelectorAll('.modal'));
+    function showStep(stepId, recordHistory) {
+      $('.wizard-step').hide();
+      $('#' + stepId).show();
+      if (recordHistory !== false) stepHistory.push(stepId);
+      const showBack = stepHistory.length > 1
+          && stepId !== 'step-landing'
+          && stepId !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(stepId);
+    }
 
-      // Load mismatches
-      loadMismatches();
-    });
+    function goBack() {
+      stepHistory.pop();
+      const prev = stepHistory[stepHistory.length - 1] || 'step-landing';
+      $('.wizard-step').hide();
+      $('#' + prev).show();
+      const showBack = stepHistory.length > 1
+          && prev !== 'step-landing'
+          && prev !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(prev);
+    }
 
-    function loadMismatches() {
+    function resetToLanding() {
+      state.entry = null;
+      state.group = null;
+      state.operation = null;
+      state.sourcePilot = null;
+      state.destPilot = null;
+      state.sourceRound = null;
+      state.targetPilot = null;
+      stepHistory.length = 0;
+      stepHistory.push('step-landing');
+      $('.wizard-step').hide();
+      $('#step-landing').show();
+      $('#wizardBackBtn').hide();
+      updateContextStrip('step-landing');
+      fetchDetection();
+    }
+
+    function updateContextStrip(stepId) {
+      const $ctx = $('#wizardContext');
+      if (!state.group || stepId === 'step-landing' || stepId === 'step-manual-picker') {
+        $ctx.hide().text('');
+        return;
+      }
+      const typeLabel = roundTypeLabel(state.group.roundType);
+      const classLabel = state.group.className;
+      let text;
+      if (state.entry === 'detected') {
+        text = 'Resolving: ' + classLabel + ' — ' + typeLabel
+            + ' (counts span ' + state.group.minCount + ' to ' + state.group.maxCount + ')';
+      } else {
+        text = 'Manual fix: ' + classLabel + ' — ' + typeLabel;
+      }
+      $ctx.text(text).show();
+    }
+
+    function roundTypeLabel(rt) {
+      if (rt === 'KNOWN') return 'Known Rounds';
+      if (rt === 'UNKNOWN') return 'Unknown Rounds';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function roundTypeTitle(rt) {
+      if (rt === 'KNOWN') return 'Known';
+      if (rt === 'UNKNOWN') return 'Unknown';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function fetchDetection() {
       $('#loadingState').show();
       $('#noMismatches').hide();
       $('#mismatchesContainer').empty();
-
       $.ajax({
-        type: "GET",
-        url: "/api/scores/mismatches",
-        dataType: "json",
-        success: function(data) {
-          $('#loadingState').hide();
-
-          if (!data.mismatches || data.mismatches.length === 0) {
-            $('#noMismatches').show();
-            return;
-          }
-
-          renderMismatches(data.mismatches);
+        url: '/api/scores/mismatches',
+        cache: false,
+        type: 'GET',
+        dataType: 'json',
+        success: function (data) {
+          state.allGroups = data.allGroups || [];
+          state.mismatches = data.mismatches || [];
+          renderLanding();
         },
-        error: function(err) {
+        error: function () {
           $('#loadingState').hide();
-          M.toast({ html: 'Error loading mismatches', classes: 'red' });
+          M.toast({ html: 'Could not load detection data', classes: 'red' });
         }
       });
     }
 
-    function renderMismatches(mismatches) {
-      const container = $('#mismatchesContainer');
-
-      mismatches.forEach(function(mismatch, idx) {
-        const card = $('<div class="mismatch-card">');
-
-        // Header
-        const header = $('<div class="mismatch-header">');
-        header.append('<i class="material-icons">warning</i>');
-        header.append('<span>' + mismatch.className + ' - ' + mismatch.roundType + '</span>');
-        header.append('<span class="expected-badge">Expected: ' + mismatch.expectedRounds + ' rounds</span>');
-        card.append(header);
-
-        // Too many group
-        if (mismatch.tooMany && mismatch.tooMany.length > 0) {
-          const tooManyGroup = $('<div class="pilot-group">');
-          tooManyGroup.append('<div class="pilot-group-title">Too many rounds:</div>');
-
-          mismatch.tooMany.forEach(function(pilot) {
-            const row = $('<div class="pilot-row too-many">');
-            row.append('<label><input type="radio" name="source_' + idx + '" class="with-gap source-radio" data-pilot=\'' + JSON.stringify(pilot) + '\'/><span class="pilot-name">' + pilot.name + '</span></label>');
-            row.append('<span class="round-badge plus">+' + (pilot.roundCount - mismatch.expectedRounds) + ' (' + pilot.roundCount + ' rounds)</span>');
-            tooManyGroup.append(row);
-          });
-          card.append(tooManyGroup);
-        }
-
-        // Too few group
-        if (mismatch.tooFew && mismatch.tooFew.length > 0) {
-          const tooFewGroup = $('<div class="pilot-group">');
-          tooFewGroup.append('<div class="pilot-group-title">Too few rounds:</div>');
-
-          mismatch.tooFew.forEach(function(pilot) {
-            const row = $('<div class="pilot-row too-few">');
-            row.append('<label><input type="radio" name="dest_' + idx + '" class="with-gap dest-radio" data-pilot=\'' + JSON.stringify(pilot) + '\'/><span class="pilot-name">' + pilot.name + '</span></label>');
-            row.append('<span class="round-badge minus">' + (pilot.roundCount - mismatch.expectedRounds) + ' (' + pilot.roundCount + ' rounds)</span>');
-            tooFewGroup.append(row);
-          });
-          card.append(tooFewGroup);
-        }
-
-        // Resolve button
-        card.append('<div class="center"><a href="#" class="waves-effect waves-light btn orange darken-1 resolve-btn" data-idx="' + idx + '"><i class="material-icons left">build</i>Resolve Selected</a></div>');
-
-        container.append(card);
-      });
-
-      // Use event delegation for reliable click handling
-      container.off('click', '.resolve-btn').on('click', '.resolve-btn', function(e) {
-        e.preventDefault();
-        const idx = $(this).data('idx');
-        openResolveModal(idx, mismatches[idx]);
-      });
-    }
-
-    function openResolveModal(idx, mismatch) {
-      // Get selected pilots
-      const sourceRadio = $('input[name="source_' + idx + '"]:checked');
-      const destRadio = $('input[name="dest_' + idx + '"]:checked');
-
-      if (sourceRadio.length === 0 || destRadio.length === 0) {
-        M.toast({ html: 'Select one pilot from each group', classes: 'orange' });
+    function renderLanding() {
+      $('#loadingState').hide();
+      const $container = $('#mismatchesContainer').empty();
+      if (state.mismatches.length === 0) {
+        $('#noMismatches').show();
         return;
       }
+      $('#noMismatches').hide();
+      state.mismatches.forEach(function (g) {
+        const $card = $('<div class="mismatch-card">');
+        const title = g.className + ' — ' + roundTypeLabel(g.roundType);
+        $card.append($('<div class="mismatch-card-title">').text(title));
+        if ((g.anomalies || []).indexOf('count_gap') !== -1) {
+          $card.append($('<div class="mismatch-card-line">').text(
+              'Counts span ' + g.minCount + ' to ' + g.maxCount + '.'));
+        }
+        if ((g.anomalies || []).indexOf('incomplete_round') !== -1) {
+          (g.pilots || []).forEach(function (p) {
+            if (p.incompleteRound != null) {
+              $card.append($('<div class="mismatch-card-line">').text(
+                  p.name + ' — Round ' + p.incompleteRound + ' incomplete (sequence 2 missing).'));
+            }
+          });
+        }
+        $card.on('click', function () {
+          state.entry = 'detected';
+          state.group = g;
+          stepHistory.length = 0;
+          stepHistory.push('step-landing');
+          showStep('step-op-choice');
+          renderStep1();
+        });
+        $container.append($card);
+      });
+    }
 
-      const sourcePilot = sourceRadio.data('pilot');
-      const destPilot = destRadio.data('pilot');
-
-      currentMismatch = {
-        mismatch: mismatch,
-        sourcePilot: sourcePilot,
-        destPilot: destPilot
-      };
-
-      // Update modal
-      $('#modalSourceName').text(sourcePilot.name);
-      $('#modalSourceRounds').text(sourcePilot.roundCount + ' ' + mismatch.roundType + ' rounds');
-      $('#modalDestName').text(destPilot.name);
-      $('#modalDestRounds').text(destPilot.roundCount + ' ' + mismatch.roundType + ' rounds');
-
-      // Generate round options - rounds after what dest already has could be the misscored one
-      const roundOptions = $('#roundOptions');
-      roundOptions.empty();
-
-      const startRound = destPilot.roundCount + 1;
-      for (let r = startRound; r <= sourcePilot.roundCount; r++) {
-        const option = $('<div class="round-option">');
-        option.append('<label><input type="radio" name="round_select" class="with-gap" value="' + r + '"/><span>Round ' + r + '</span></label>');
-        roundOptions.append(option);
-      }
-
-      // Reset state
-      selectedRound = null;
-      $('#previewBox').hide();
-      $('#confirmMoveBtn').addClass('disabled');
-
-      // Bind round selection
-      $('input[name="round_select"]').change(function() {
-        selectedRound = parseInt($(this).val());
-        showPreview();
+    function renderManualPicker() {
+      const $rows = $('#manualPickerRows').empty();
+      const byClass = {};
+      let freestyle = null;
+      state.allGroups.forEach(function (g) {
+        if (g.className === 'FREESTYLE') {
+          freestyle = g;
+          return;
+        }
+        if (!byClass[g.className]) byClass[g.className] = [];
+        byClass[g.className].push(g);
       });
 
-      // Open modal
-      M.Modal.getInstance(document.getElementById('resolveModal')).open();
-    }
+      Object.keys(byClass).forEach(function (className) {
+        const groups = byClass[className];
+        const $row = $('<div class="manual-class-row">');
+        $row.append($('<div class="manual-class-label">').text(className));
+        ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
+          const g = groups.find(function (x) { return x.roundType === rt; });
+          if (!g) return;
+          const $btn = $('<a href="#" class="manual-type-btn">').text(roundTypeTitle(rt));
+          $btn.on('click', function (e) {
+            e.preventDefault();
+            state.entry = 'manual';
+            state.group = g;
+            stepHistory.length = 0;
+            stepHistory.push('step-landing');
+            stepHistory.push('step-manual-picker');
+            showStep('step-op-choice');
+            renderStep1();
+          });
+          $row.append($btn);
+        });
+        $rows.append($row);
+      });
 
-    function showPreview() {
-      if (!selectedRound || !currentMismatch) return;
-
-      const source = currentMismatch.sourcePilot;
-      const dest = currentMismatch.destPilot;
-      const mismatch = currentMismatch.mismatch;
-      const destRound = dest.roundCount + 1;
-
-      let preview = '';
-      preview += '<div class="preview-item"><i class="material-icons green-text">arrow_forward</i>Move ' + mismatch.roundType + ' Round ' + selectedRound + ' from ' + source.name + ' to ' + dest.name + ' as Round ' + destRound + '</div>';
-
-      // If moving a middle round, show renumbering
-      if (selectedRound < source.roundCount) {
-        for (let r = selectedRound + 1; r <= source.roundCount; r++) {
-          preview += '<div class="preview-item"><i class="material-icons blue-text">swap_vert</i>' + source.name + ' Round ' + r + ' becomes Round ' + (r - 1) + '</div>';
-        }
+      if (freestyle) {
+        $rows.append($('<div class="manual-divider">'));
+        const $fsRow = $('<div class="manual-freestyle-row">');
+        const $btn = $('<a href="#" class="manual-type-btn">').text('Freestyle');
+        $btn.on('click', function (e) {
+          e.preventDefault();
+          state.entry = 'manual';
+          state.group = freestyle;
+          stepHistory.length = 0;
+          stepHistory.push('step-landing');
+          stepHistory.push('step-manual-picker');
+          showStep('step-op-choice');
+          renderStep1();
+        });
+        $fsRow.append($btn);
+        $rows.append($fsRow);
       }
-
-      const newActiveRound = Math.max(source.roundCount - 1, destRound) + 1;
-      preview += '<div class="preview-item"><i class="material-icons orange-text">update</i>Both pilots: next ' + mismatch.roundType + ' round = ' + newActiveRound + '</div>';
-      preview += '<div class="preview-item"><i class="material-icons purple-text">comment</i>Audit comment added to moved round</div>';
-
-      $('#previewContent').html(preview);
-      $('#previewBox').show();
-      $('#confirmMoveBtn').removeClass('disabled');
     }
 
-    $('#confirmMoveBtn').click(function(e) {
-      e.preventDefault();
-      if ($(this).hasClass('disabled')) return;
+    function renderStep1() {
+      const pilots = state.group.pilots || [];
+      const $ctx = $('#step1PilotContext').empty();
+      const minC = state.group.minCount;
+      const maxC = state.group.maxCount;
+      pilots.forEach(function (p) {
+        const $row = $('<div class="pilot-context-row">');
+        if (p.roundCount !== minC || p.roundCount !== maxC) {
+          if (p.roundCount === minC && minC !== maxC) $row.addClass('is-mismatch');
+          if (p.incompleteRound != null) $row.addClass('is-mismatch');
+        }
+        $row.append($('<span>').text(p.name));
+        let count = p.roundCount + ' ' + roundTypeTitle(state.group.roundType) + ' rounds';
+        if (p.incompleteRound != null) count += ' (round ' + p.incompleteRound + ' incomplete)';
+        $row.append($('<span>').text(count));
+        $ctx.append($row);
+      });
 
-      const payload = {
-        sourcePilotId: currentMismatch.sourcePilot.pilotId,
-        destPilotId: currentMismatch.destPilot.pilotId,
-        roundType: currentMismatch.mismatch.roundType,
-        sourceRound: selectedRound
-      };
+      const hasIncomplete = pilots.some(function (p) { return p.incompleteRound != null; });
+      const spread = maxC - minC;
+      const fixEnabled = hasIncomplete;
+      const moveEnabled = spread >= 1;
 
-      $(this).addClass('disabled').text('Moving...');
+      $('#opFixBtn').toggleClass('disabled', !fixEnabled);
+      $('#opMoveBtn').toggleClass('disabled', !moveEnabled);
+      $('#step1NothingActionable').toggle(!fixEnabled && !moveEnabled && state.entry === 'manual');
+    }
 
+    function renderFixPick() {
+      const $list = $('#fixPilotList').empty();
+      const pilots = (state.group.pilots || [])
+          .filter(function (p) { return p.incompleteRound != null; })
+          .slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      pilots.forEach(function (p) {
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        $row.append($('<div class="row-meta">').text(
+            'Round ' + p.incompleteRound + ' missing seq 2'));
+        $row.on('click', function (e) {
+          e.preventDefault();
+          state.targetPilot = p;
+          showStep('step-confirm');
+          renderConfirmFix();
+        });
+        $list.append($row);
+      });
+    }
+
+    function renderMoveSource() {
+      const $list = $('#moveSourceList').empty();
+      const pilots = (state.group.pilots || []).slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      const minC = state.group.minCount;
+      pilots.forEach(function (p) {
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        const meta = p.roundCount + ' ' + roundTypeTitle(state.group.roundType) + ' rounds';
+        $row.append($('<div class="row-meta">').text(meta));
+        let disabled = false;
+        let caption = null;
+        if (p.incompleteRound != null) {
+          disabled = true;
+          caption = 'Mark missing sequence first';
+        } else if (p.roundCount === minC) {
+          disabled = true;
+          caption = 'No extra round to give';
+        }
+        if (caption) $row.append($('<div class="row-caption">').text(caption));
+        if (disabled) {
+          $row.addClass('disabled');
+        } else {
+          $row.on('click', function (e) {
+            e.preventDefault();
+            state.sourcePilot = p;
+            showStep('step-move-dest');
+            renderMoveDest();
+          });
+        }
+        $list.append($row);
+      });
+    }
+
+    function renderMoveDest() {
+      const $list = $('#moveDestList').empty();
+      const pilots = (state.group.pilots || []).slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      const sourceCount = state.sourcePilot.roundCount;
+      pilots.forEach(function (p) {
+        if (p.pilotId === state.sourcePilot.pilotId) return;
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        const meta = p.roundCount + ' ' + roundTypeTitle(state.group.roundType) + ' rounds';
+        $row.append($('<div class="row-meta">').text(meta));
+        let disabled = false;
+        let caption = null;
+        if (p.incompleteRound != null) {
+          disabled = true;
+          caption = 'Mark missing sequence first';
+        } else if (p.roundCount >= sourceCount) {
+          disabled = true;
+          caption = 'Already caught up';
+        }
+        if (caption) $row.append($('<div class="row-caption">').text(caption));
+        if (disabled) {
+          $row.addClass('disabled');
+        } else {
+          $row.on('click', function (e) {
+            e.preventDefault();
+            state.destPilot = p;
+            showStep('step-move-round');
+            renderMoveRound();
+          });
+        }
+        $list.append($row);
+      });
+    }
+
+    function renderMoveRound() {
+      $('#moveRoundTitle').text('Which round on ' + state.sourcePilot.name
+          + ' belongs to ' + state.destPilot.name + '?');
+      const $list = $('#moveRoundList').empty();
+      const start = state.destPilot.roundCount + 1;
+      const end = state.sourcePilot.roundCount;
+      for (let r = start; r <= end; r++) {
+        const round = r;
+        const $row = $('<a href="#" class="round-pick-row">').text(
+            roundTypeTitle(state.group.roundType) + ' Round ' + round);
+        $row.on('click', function (e) {
+          e.preventDefault();
+          state.sourceRound = round;
+          showStep('step-confirm');
+          renderConfirmMove();
+        });
+        $list.append($row);
+      }
+    }
+
+    function renderConfirmFix() {
+      const p = state.targetPilot;
+      const typeTitle = roundTypeTitle(state.group.roundType);
+      const $box = $('#confirmBox').empty();
+      $box.append($('<div class="confirm-action">').text(
+          'Mark ' + p.name + "'s " + typeTitle + ' Round ' + p.incompleteRound
+          + ' sequence 2 as 0.0 (not flown)?'));
+      $box.append($('<div class="confirm-after-title">').text('After this:'));
+      const afterCount = p.roundCount;
+      $box.append($('<div class="confirm-line">').text(
+          '- ' + p.name + ': ' + afterCount + ' ' + typeTitle + ' rounds'
+          + ' (next: Round ' + (afterCount + 1) + ')'));
+      $('#confirmActionBtn').text('Confirm Fix');
+    }
+
+    function renderConfirmMove() {
+      const src = state.sourcePilot;
+      const dst = state.destPilot;
+      const typeTitle = roundTypeTitle(state.group.roundType);
+      const $box = $('#confirmBox').empty();
+      $box.append($('<div class="confirm-action">').text(
+          'Move ' + src.name + "'s " + typeTitle + ' Round ' + state.sourceRound
+          + ' to ' + dst.name + '.'));
+      $box.append($('<div class="confirm-after-title">').text('After this:'));
+      const srcAfter = src.roundCount - 1;
+      const dstAfter = dst.roundCount + 1;
+      $box.append($('<div class="confirm-line">').text(
+          '- ' + src.name + ': ' + srcAfter + ' ' + typeTitle + ' rounds'
+          + ' (next: Round ' + (srcAfter + 1) + ')'));
+      $box.append($('<div class="confirm-line">').text(
+          '- ' + dst.name + ': ' + dstAfter + ' ' + typeTitle + ' rounds'
+          + ' (next: Round ' + (dstAfter + 1) + ')'));
+      $('#confirmActionBtn').text('Confirm Move');
+    }
+
+    function executeFix() {
       $.ajax({
-        type: "POST",
-        url: "/api/scores/move-round",
-        data: JSON.stringify(payload),
-        contentType: "application/json; charset=utf-8",
-        dataType: "json",
-        success: function(data) {
-          M.Modal.getInstance(document.getElementById('resolveModal')).close();
-          M.toast({ html: 'Round moved successfully', classes: 'green' });
-
-          // Reload mismatches
-          loadMismatches();
-        },
-        error: function(err) {
-          $('#confirmMoveBtn').removeClass('disabled').html('<i class="material-icons left">check</i>Confirm Move');
-          var msg = 'Error moving round';
-          if (err.responseJSON && err.responseJSON.message) {
-            msg = err.responseJSON.message;
+        url: '/api/scores/fix-missing-sequence',
+        cache: false,
+        type: 'POST',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        data: JSON.stringify({
+          pilotId: state.targetPilot.pilotId,
+          roundType: state.group.roundType,
+          round: state.targetPilot.incompleteRound
+        }),
+        success: function (data) {
+          if (data.result === 'ok') {
+            $('#resultMessage').text('Sequence marked as not flown.');
+            showStep('step-result');
+          } else {
+            M.toast({ html: data.message || 'Fix failed', classes: 'red' });
           }
+        },
+        error: function (errObj) {
+          const msg = errObj.responseJSON && errObj.responseJSON.message
+              ? errObj.responseJSON.message
+              : 'Fix failed';
           M.toast({ html: msg, classes: 'red' });
         }
       });
+    }
+
+    function executeMove() {
+      $.ajax({
+        url: '/api/scores/move-round',
+        cache: false,
+        type: 'POST',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        data: JSON.stringify({
+          sourcePilotId: state.sourcePilot.pilotId,
+          destPilotId: state.destPilot.pilotId,
+          roundType: state.group.roundType,
+          sourceRound: state.sourceRound
+        }),
+        success: function (data) {
+          if (data.result === 'ok') {
+            $('#resultMessage').text('Round moved.');
+            showStep('step-result');
+          } else {
+            M.toast({ html: data.message || 'Move failed', classes: 'red' });
+          }
+        },
+        error: function (errObj) {
+          const msg = errObj.responseJSON && errObj.responseJSON.message
+              ? errObj.responseJSON.message
+              : 'Move failed';
+          M.toast({ html: msg, classes: 'red' });
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      stepHistory.push('step-landing');
+      fetchDetection();
+    });
+
+    $('#wizardBackBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#forceRoundEditsBtn').on('click', function (e) {
+      e.preventDefault();
+      showStep('step-manual-picker');
+      renderManualPicker();
+    });
+
+    $('#opFixBtn').on('click', function (e) {
+      e.preventDefault();
+      if ($(this).hasClass('disabled')) return;
+      state.operation = 'fix';
+      showStep('step-fix-pick');
+      renderFixPick();
+    });
+
+    $('#opMoveBtn').on('click', function (e) {
+      e.preventDefault();
+      if ($(this).hasClass('disabled')) return;
+      state.operation = 'move';
+      showStep('step-move-source');
+      renderMoveSource();
+    });
+
+    $('#confirmCancelBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#confirmActionBtn').on('click', function (e) {
+      e.preventDefault();
+      if (state.operation === 'fix') executeFix();
+      else if (state.operation === 'move') executeMove();
+    });
+
+    $('#resultDoneBtn').on('click', function (e) {
+      e.preventDefault();
+      resetToLanding();
     });
   </script>
 

--- a/judge/src/main/resources/templates/adminScoresSwap.html
+++ b/judge/src/main/resources/templates/adminScoresSwap.html
@@ -64,15 +64,22 @@
     .picker-class-row {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       gap: 8px;
-      padding: 6px 0;
+      padding: 8px 14px;
+      margin-bottom: 6px;
+      border: 1px solid #90a4ae;
+      border-radius: 6px;
     }
     .picker-class-label {
-      flex: 0 0 130px;
       font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
+    }
+    .picker-class-btns {
+      display: flex;
+      gap: 8px;
     }
     .picker-type-btn {
       padding: 8px 14px;
@@ -388,6 +395,7 @@
         const groups = byClass[className];
         const $row = $('<div class="picker-class-row">');
         $row.append($('<div class="picker-class-label">').text(className));
+        const $btns = $('<div class="picker-class-btns">');
         ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
           const g = groups.find(function (x) { return x.roundType === rt; });
           if (!g) return;
@@ -400,14 +408,16 @@
             showStep('step-round-pick');
             renderRoundPick();
           });
-          $row.append($btn);
+          $btns.append($btn);
         });
+        $row.append($btns);
         $rows.append($row);
       });
 
       if (freestyle) {
-        $rows.append($('<div class="picker-divider">'));
-        const $fsRow = $('<div class="picker-freestyle-row">');
+        const $row = $('<div class="picker-class-row">');
+        $row.append($('<div class="picker-class-label">').text('FREESTYLE'));
+        const $btns = $('<div class="picker-class-btns">');
         const $btn = $('<a href="#" class="picker-type-btn">').text('Freestyle');
         $btn.on('click', function (e) {
           e.preventDefault();
@@ -417,8 +427,9 @@
           showStep('step-round-pick');
           renderRoundPick();
         });
-        $fsRow.append($btn);
-        $rows.append($fsRow);
+        $btns.append($btn);
+        $row.append($btns);
+        $rows.append($row);
       }
     }
 

--- a/judge/src/main/resources/templates/adminScoresSwap.html
+++ b/judge/src/main/resources/templates/adminScoresSwap.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+  <title>Swap Round Scores</title>
+
+  <!-- CSS  -->
+  <link href="/materialize/css/material_lcons.css" rel="stylesheet">
+  <link href="/materialize/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection" />
+  <style>
+    .header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      margin-top: 10px;
+      margin-bottom: 8px;
+    }
+    .heading {
+      font-size: calc(1.2vw + 2vh) !important;
+      margin: 0;
+    }
+    .nav-buttons {
+      display: flex;
+      gap: 5px;
+      flex-wrap: wrap;
+    }
+    .admin-nav-btn {
+      margin: 2px;
+      padding: 0 12px;
+    }
+    .wizard-context {
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: #455a64;
+      margin: 4px 0 12px;
+    }
+    .step-section-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #455a64;
+      margin: 10px 0 8px;
+    }
+    .all-clear {
+      text-align: center;
+      padding: 16px;
+      color: #2e7d32;
+    }
+    .all-clear i {
+      font-size: 3.5rem;
+      color: #4caf50;
+      display: block;
+      margin-bottom: 8px;
+    }
+    .all-clear-title {
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+    .loading-spinner {
+      text-align: center;
+      padding: 20px;
+    }
+    .picker-class-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+    }
+    .picker-class-label {
+      flex: 0 0 110px;
+      font-weight: 600;
+      text-transform: uppercase;
+      color: #263238;
+    }
+    .picker-type-btn {
+      padding: 6px 14px;
+      border: 2px solid #90a4ae;
+      border-radius: 6px;
+      background: #fafafa;
+      color: #263238;
+      font-size: 0.95rem;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .picker-type-btn:active {
+      background: #eceff1;
+    }
+    .picker-divider {
+      border-top: 1px solid #cfd8dc;
+      margin: 10px 0 8px;
+    }
+    .picker-freestyle-row {
+      text-align: center;
+      margin-top: 8px;
+    }
+    .pick-row {
+      display: block;
+      padding: 10px 14px;
+      margin-bottom: 6px;
+      border: 2px solid #90a4ae;
+      border-radius: 8px;
+      background: #fafafa;
+      font-size: 1rem;
+      color: #263238;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .pick-row:active {
+      background: #eceff1;
+    }
+    .pick-row .row-name {
+      font-weight: 500;
+    }
+    .pick-row .row-meta {
+      font-size: 0.9rem;
+      color: #555;
+    }
+    .pick-row.disabled {
+      background: #e0e0e0;
+      color: #757575;
+      border-color: #bdbdbd;
+      cursor: default;
+    }
+    .pick-row.disabled .row-meta,
+    .pick-row .row-caption {
+      color: #616161;
+      font-size: 0.85rem;
+    }
+    .round-pick-row {
+      display: block;
+      padding: 12px 16px;
+      margin-bottom: 6px;
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      font-size: 1.1rem;
+      font-weight: 600;
+      text-align: center;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .round-pick-row:active {
+      background: #bbdefb;
+    }
+    .confirm-box {
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      padding: 12px 16px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      margin: 10px 0;
+    }
+    .confirm-action {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    .confirm-after-line {
+      font-size: 1rem;
+      margin: 4px 0;
+    }
+    .confirm-buttons {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      margin-top: 12px;
+    }
+    .result-box {
+      text-align: center;
+      padding: 18px;
+      margin: 14px 0;
+      border-radius: 8px;
+      background: #e8f5e9;
+      color: #1b5e20;
+    }
+    .result-icon {
+      font-size: 3rem;
+    }
+    .result-message {
+      font-size: 1.2rem;
+      font-weight: 500;
+      margin: 8px 0;
+    }
+  </style>
+</head>
+
+<body class="orange lighten-4">
+  <div th:replace="~{banner::line_judge}"></div>
+  <div th:replace="~{banner::status}"></div>
+
+  <div class="section no-pad-bot orange lighten-4" id="index-banner">
+    <div class="container orange lighten-4 black-text">
+
+      <div class="header-row">
+        <h2 class="heading">Swap Round Scores</h2>
+        <div class="nav-buttons">
+          <a href="#" id="wizardBackBtn" class="waves-effect waves-light btn blue-grey admin-nav-btn" style="display:none;">
+            <i class="material-icons left">arrow_back</i>Back
+          </a>
+          <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
+            <i class="material-icons left">arrow_back</i>Score Fixes
+          </a>
+          <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
+            <i class="material-icons left">exit_to_app</i>Exit
+          </a>
+        </div>
+      </div>
+
+      <div id="wizardContext" class="wizard-context" style="display:none;"></div>
+
+      <!-- Step 1: class/type picker -->
+      <div class="wizard-step" id="step-picker">
+        <div id="loadingState" class="loading-spinner">
+          <div class="preloader-wrapper big active">
+            <div class="spinner-layer spinner-blue-only">
+              <div class="circle-clipper left"><div class="circle"></div></div>
+              <div class="gap-patch"><div class="circle"></div></div>
+              <div class="circle-clipper right"><div class="circle"></div></div>
+            </div>
+          </div>
+          <p>Scanning for swap candidates...</p>
+        </div>
+
+        <div id="noEligible" class="all-clear" style="display:none;">
+          <i class="material-icons">check_circle</i>
+          <div class="all-clear-title">No swap candidates — every (class, round) is unique per pilot or has only one pilot</div>
+        </div>
+
+        <div id="pickerWrap" style="display:none;">
+          <div class="step-section-title">Pick a class and round type:</div>
+          <div id="pickerRows"></div>
+        </div>
+      </div>
+
+      <!-- Step 2: round pick -->
+      <div class="wizard-step" id="step-round-pick" style="display:none;">
+        <div class="step-section-title">Pick round to swap:</div>
+        <div id="roundPickList"></div>
+      </div>
+
+      <!-- Step 3: first pilot -->
+      <div class="wizard-step" id="step-first-pilot" style="display:none;">
+        <div class="step-section-title">Pick first pilot:</div>
+        <div id="firstPilotList"></div>
+      </div>
+
+      <!-- Step 4: second pilot -->
+      <div class="wizard-step" id="step-second-pilot" style="display:none;">
+        <div class="step-section-title">Pick second pilot:</div>
+        <div id="secondPilotList"></div>
+      </div>
+
+      <!-- Step 5: confirm -->
+      <div class="wizard-step" id="step-confirm" style="display:none;">
+        <div class="confirm-box" id="confirmBox"></div>
+        <div class="confirm-buttons">
+          <a href="#" id="confirmCancelBtn" class="waves-effect waves-light btn-flat">Cancel</a>
+          <a href="#" id="confirmActionBtn" class="waves-effect waves-light btn green">Confirm Swap</a>
+        </div>
+      </div>
+
+      <!-- Step 6: result -->
+      <div class="wizard-step" id="step-result" style="display:none;">
+        <div class="result-box">
+          <i class="material-icons result-icon">check_circle</i>
+          <div class="result-message">Round scores swapped.</div>
+        </div>
+        <div class="confirm-buttons">
+          <a href="/admin/scores" class="waves-effect waves-light btn green">Done</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!--  Scripts-->
+  <script src="/jquery-3.6.4.min.js"></script>
+  <script src="/materialize/js/materialize.js"></script>
+  <script>
+    /* Swap Round wizard — single-page state machine. */
+    const state = {
+      group: null,           // selected (class, roundType)
+      round: null,           // selected round
+      firstPilot: null,
+      secondPilot: null,
+      allGroups: []
+    };
+    const stepHistory = [];
+
+    function showStep(stepId, recordHistory) {
+      $('.wizard-step').hide();
+      $('#' + stepId).show();
+      if (recordHistory !== false) stepHistory.push(stepId);
+      const showBack = stepHistory.length > 1
+          && stepId !== 'step-picker'
+          && stepId !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(stepId);
+    }
+
+    function goBack() {
+      stepHistory.pop();
+      const prev = stepHistory[stepHistory.length - 1] || 'step-picker';
+      $('.wizard-step').hide();
+      $('#' + prev).show();
+      const showBack = stepHistory.length > 1
+          && prev !== 'step-picker'
+          && prev !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(prev);
+    }
+
+    function updateContextStrip(stepId) {
+      const $ctx = $('#wizardContext');
+      if (!state.group || stepId === 'step-picker') {
+        $ctx.hide().text('');
+        return;
+      }
+      $ctx.text('Swap Round Scores: ' + state.group.className + ' — ' + roundTypeLabel(state.group.roundType)).show();
+    }
+
+    function roundTypeLabel(rt) {
+      if (rt === 'KNOWN') return 'Known Rounds';
+      if (rt === 'UNKNOWN') return 'Unknown Rounds';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function roundTypeTitle(rt) {
+      if (rt === 'KNOWN') return 'Known';
+      if (rt === 'UNKNOWN') return 'Unknown';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function groupHasSwapCandidates(g) {
+      const withRounds = (g.pilots || []).filter(function (p) { return p.roundCount >= 1; });
+      return withRounds.length >= 2;
+    }
+
+    function fetchGroups() {
+      $('#loadingState').show();
+      $('#noEligible').hide();
+      $('#pickerWrap').hide();
+      $.ajax({
+        url: '/api/scores/mismatches',
+        cache: false,
+        type: 'GET',
+        dataType: 'json',
+        success: function (data) {
+          state.allGroups = (data.allGroups || []).filter(groupHasSwapCandidates);
+          renderPicker();
+        },
+        error: function () {
+          $('#loadingState').hide();
+          M.toast({ html: 'Could not load detection data', classes: 'red' });
+        }
+      });
+    }
+
+    function renderPicker() {
+      $('#loadingState').hide();
+      if (state.allGroups.length === 0) {
+        $('#noEligible').show();
+        $('#pickerWrap').hide();
+        return;
+      }
+      $('#noEligible').hide();
+      $('#pickerWrap').show();
+      const $rows = $('#pickerRows').empty();
+
+      const byClass = {};
+      let freestyle = null;
+      state.allGroups.forEach(function (g) {
+        if (g.className === 'FREESTYLE') {
+          freestyle = g;
+          return;
+        }
+        if (!byClass[g.className]) byClass[g.className] = [];
+        byClass[g.className].push(g);
+      });
+
+      Object.keys(byClass).forEach(function (className) {
+        const groups = byClass[className];
+        const $row = $('<div class="picker-class-row">');
+        $row.append($('<div class="picker-class-label">').text(className));
+        ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
+          const g = groups.find(function (x) { return x.roundType === rt; });
+          if (!g) return;
+          const $btn = $('<a href="#" class="picker-type-btn">').text(roundTypeTitle(rt));
+          $btn.on('click', function (e) {
+            e.preventDefault();
+            state.group = g;
+            stepHistory.length = 0;
+            stepHistory.push('step-picker');
+            showStep('step-round-pick');
+            renderRoundPick();
+          });
+          $row.append($btn);
+        });
+        $rows.append($row);
+      });
+
+      if (freestyle) {
+        $rows.append($('<div class="picker-divider">'));
+        const $fsRow = $('<div class="picker-freestyle-row">');
+        const $btn = $('<a href="#" class="picker-type-btn">').text('Freestyle');
+        $btn.on('click', function (e) {
+          e.preventDefault();
+          state.group = freestyle;
+          stepHistory.length = 0;
+          stepHistory.push('step-picker');
+          showStep('step-round-pick');
+          renderRoundPick();
+        });
+        $fsRow.append($btn);
+        $rows.append($fsRow);
+      }
+    }
+
+    function renderRoundPick() {
+      const $list = $('#roundPickList').empty();
+      const pilots = state.group.pilots || [];
+      const maxC = state.group.maxCount;
+      for (let r = 1; r <= maxC; r++) {
+        const round = r;
+        const pilotsForRound = pilots.filter(function (p) { return p.roundCount >= round; });
+        if (pilotsForRound.length < 2) continue;
+        const $row = $('<a href="#" class="round-pick-row">').text(
+            roundTypeTitle(state.group.roundType) + ' Round ' + round);
+        $row.on('click', function (e) {
+          e.preventDefault();
+          state.round = round;
+          showStep('step-first-pilot');
+          renderFirstPilot();
+        });
+        $list.append($row);
+      }
+    }
+
+    function renderFirstPilot() {
+      const $list = $('#firstPilotList').empty();
+      const pilots = (state.group.pilots || [])
+          .filter(function (p) { return p.roundCount >= state.round; })
+          .slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      pilots.forEach(function (p) {
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        $row.on('click', function (e) {
+          e.preventDefault();
+          state.firstPilot = p;
+          showStep('step-second-pilot');
+          renderSecondPilot();
+        });
+        $list.append($row);
+      });
+    }
+
+    function renderSecondPilot() {
+      const $list = $('#secondPilotList').empty();
+      const pilots = (state.group.pilots || [])
+          .filter(function (p) { return p.roundCount >= state.round && p.pilotId !== state.firstPilot.pilotId; })
+          .slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      const isKnown = state.group.roundType === 'KNOWN';
+      const firstIncomplete = isKnown && state.firstPilot.incompleteRound === state.round;
+      pilots.forEach(function (p) {
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        const candidateIncomplete = isKnown && p.incompleteRound === state.round;
+        const seqMismatch = isKnown && (firstIncomplete !== candidateIncomplete);
+        if (seqMismatch) {
+          $row.addClass('disabled');
+          $row.append($('<div class="row-caption">').text(
+              "Sequences don't match — fix incomplete round first"));
+        } else {
+          $row.on('click', function (e) {
+            e.preventDefault();
+            state.secondPilot = p;
+            showStep('step-confirm');
+            renderConfirm();
+          });
+        }
+        $list.append($row);
+      });
+    }
+
+    function renderConfirm() {
+      const a = state.firstPilot;
+      const b = state.secondPilot;
+      const typeTitle = roundTypeTitle(state.group.roundType);
+      const $box = $('#confirmBox').empty();
+      $box.append($('<div class="confirm-action">').text(
+          'Swap ' + a.name + "'s and " + b.name + "'s " + typeTitle + ' Round ' + state.round + ' scores.'));
+      $box.append($('<div class="confirm-after-line">').text(
+          'After: counts unchanged for both pilots.'));
+    }
+
+    function executeSwap() {
+      $.ajax({
+        url: '/api/scores/swap-round',
+        cache: false,
+        type: 'POST',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        data: JSON.stringify({
+          pilotIdA: state.firstPilot.pilotId,
+          pilotIdB: state.secondPilot.pilotId,
+          roundType: state.group.roundType,
+          round: state.round
+        }),
+        success: function (data) {
+          if (data.result === 'ok') {
+            showStep('step-result');
+          } else {
+            M.toast({ html: data.message || 'Swap failed', classes: 'red' });
+          }
+        },
+        error: function (errObj) {
+          const msg = errObj.responseJSON && errObj.responseJSON.message
+              ? errObj.responseJSON.message
+              : 'Swap failed';
+          M.toast({ html: msg, classes: 'red' });
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      stepHistory.push('step-picker');
+      fetchGroups();
+    });
+
+    $('#wizardBackBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#confirmCancelBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#confirmActionBtn').on('click', function (e) {
+      e.preventDefault();
+      executeSwap();
+    });
+  </script>
+
+</body>
+
+</html>

--- a/judge/src/main/resources/templates/adminScoresSwap.html
+++ b/judge/src/main/resources/templates/adminScoresSwap.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 10px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.2vw + 2vh) !important;
@@ -32,30 +31,30 @@
       padding: 0 12px;
     }
     .wizard-context {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 500;
       color: #455a64;
-      margin: 4px 0 12px;
+      margin: 4px 0 8px;
     }
     .step-section-title {
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       color: #455a64;
-      margin: 10px 0 8px;
+      margin: 8px 0 6px 0;
     }
     .all-clear {
       text-align: center;
-      padding: 16px;
+      padding: 16px 10px;
       color: #2e7d32;
     }
     .all-clear i {
       font-size: 3.5rem;
       color: #4caf50;
       display: block;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
     }
     .all-clear-title {
-      font-size: 1.2rem;
+      font-size: 2.1rem;
       font-weight: 500;
     }
     .loading-spinner {
@@ -69,18 +68,19 @@
       padding: 6px 0;
     }
     .picker-class-label {
-      flex: 0 0 110px;
+      flex: 0 0 130px;
+      font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
     }
     .picker-type-btn {
-      padding: 6px 14px;
+      padding: 8px 14px;
       border: 2px solid #90a4ae;
       border-radius: 6px;
       background: #fafafa;
       color: #263238;
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       cursor: pointer;
       text-decoration: none;
     }
@@ -102,7 +102,7 @@
       border: 2px solid #90a4ae;
       border-radius: 8px;
       background: #fafafa;
-      font-size: 1rem;
+      font-size: 1.75rem;
       color: #263238;
       cursor: pointer;
       text-decoration: none;
@@ -114,19 +114,20 @@
       font-weight: 500;
     }
     .pick-row .row-meta {
-      font-size: 0.9rem;
+      font-size: 1.5rem;
       color: #555;
     }
     .pick-row.disabled {
       background: #e0e0e0;
       color: #757575;
       border-color: #bdbdbd;
-      cursor: default;
+      cursor: not-allowed;
     }
     .pick-row.disabled .row-meta,
     .pick-row .row-caption {
       color: #616161;
-      font-size: 0.85rem;
+      font-size: 1.5rem;
+      margin-top: 3px;
     }
     .round-pick-row {
       display: block;
@@ -136,7 +137,7 @@
       border-radius: 8px;
       background: #e3f2fd;
       color: #0d47a1;
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       text-align: center;
       cursor: pointer;
@@ -148,30 +149,30 @@
     .confirm-box {
       border: 2px solid #1976d2;
       border-radius: 8px;
-      padding: 12px 16px;
+      padding: 10px 14px;
       background: #e3f2fd;
       color: #0d47a1;
-      margin: 10px 0;
+      margin-bottom: 10px;
     }
     .confirm-action {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 600;
       margin-bottom: 8px;
     }
     .confirm-after-line {
-      font-size: 1rem;
+      font-size: 1.75rem;
       margin: 4px 0;
     }
     .confirm-buttons {
       display: flex;
-      gap: 12px;
+      gap: 10px;
       justify-content: center;
-      margin-top: 12px;
+      margin-top: 8px;
     }
     .result-box {
       text-align: center;
-      padding: 18px;
-      margin: 14px 0;
+      padding: 12px 16px;
+      margin: 10px 0;
       border-radius: 8px;
       background: #e8f5e9;
       color: #1b5e20;
@@ -180,7 +181,7 @@
       font-size: 3rem;
     }
     .result-message {
-      font-size: 1.2rem;
+      font-size: 1.75rem;
       font-weight: 500;
       margin: 8px 0;
     }

--- a/judge/src/main/resources/templates/adminScoresZeroFill.html
+++ b/judge/src/main/resources/templates/adminScoresZeroFill.html
@@ -1,0 +1,551 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1.0" />
+  <title>Zero Unflown Rounds</title>
+
+  <!-- CSS  -->
+  <link href="/materialize/css/material_lcons.css" rel="stylesheet">
+  <link href="/materialize/css/materialize.min.css" type="text/css" rel="stylesheet" media="screen,projection" />
+  <style>
+    .header-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      margin-top: 10px;
+      margin-bottom: 8px;
+    }
+    .heading {
+      font-size: calc(1.2vw + 2vh) !important;
+      margin: 0;
+    }
+    .nav-buttons {
+      display: flex;
+      gap: 5px;
+      flex-wrap: wrap;
+    }
+    .admin-nav-btn {
+      margin: 2px;
+      padding: 0 12px;
+    }
+    .wizard-context {
+      font-size: 1.1rem;
+      font-weight: 500;
+      color: #455a64;
+      margin: 4px 0 12px;
+    }
+    .step-section-title {
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #455a64;
+      margin: 10px 0 8px;
+    }
+    .all-clear {
+      text-align: center;
+      padding: 16px;
+      color: #2e7d32;
+    }
+    .all-clear i {
+      font-size: 3.5rem;
+      color: #4caf50;
+      display: block;
+      margin-bottom: 8px;
+    }
+    .all-clear-title {
+      font-size: 1.2rem;
+      font-weight: 500;
+    }
+    .loading-spinner {
+      text-align: center;
+      padding: 20px;
+    }
+    .picker-class-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 0;
+    }
+    .picker-class-label {
+      flex: 0 0 110px;
+      font-weight: 600;
+      text-transform: uppercase;
+      color: #263238;
+    }
+    .picker-type-btn {
+      padding: 6px 14px;
+      border: 2px solid #90a4ae;
+      border-radius: 6px;
+      background: #fafafa;
+      color: #263238;
+      font-size: 0.95rem;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .picker-type-btn:active {
+      background: #eceff1;
+    }
+    .picker-divider {
+      border-top: 1px solid #cfd8dc;
+      margin: 10px 0 8px;
+    }
+    .picker-freestyle-row {
+      text-align: center;
+      margin-top: 8px;
+    }
+    .pick-row {
+      display: block;
+      padding: 10px 14px;
+      margin-bottom: 6px;
+      border: 2px solid #90a4ae;
+      border-radius: 8px;
+      background: #fafafa;
+      font-size: 1rem;
+      color: #263238;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .pick-row:active {
+      background: #eceff1;
+    }
+    .pick-row .row-name {
+      font-weight: 500;
+    }
+    .pick-row .row-meta {
+      font-size: 0.9rem;
+      color: #555;
+    }
+    .pick-row.disabled {
+      background: #e0e0e0;
+      color: #757575;
+      border-color: #bdbdbd;
+      cursor: default;
+    }
+    .pick-row.disabled .row-meta,
+    .pick-row .row-caption {
+      color: #616161;
+      font-size: 0.85rem;
+    }
+    .round-pick-row {
+      display: block;
+      padding: 12px 16px;
+      margin-bottom: 6px;
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      font-size: 1.1rem;
+      font-weight: 600;
+      text-align: center;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .round-pick-row:active {
+      background: #bbdefb;
+    }
+    .round-pick-row.disabled {
+      background: #e0e0e0;
+      color: #757575;
+      border-color: #bdbdbd;
+      cursor: default;
+    }
+    .round-pick-row .row-caption {
+      font-size: 0.85rem;
+      color: #616161;
+      font-weight: 400;
+    }
+    .confirm-box {
+      border: 2px solid #1976d2;
+      border-radius: 8px;
+      padding: 12px 16px;
+      background: #e3f2fd;
+      color: #0d47a1;
+      margin: 10px 0;
+    }
+    .confirm-action {
+      font-size: 1.1rem;
+      font-weight: 600;
+      margin-bottom: 8px;
+    }
+    .confirm-after-line {
+      font-size: 1rem;
+      margin: 4px 0;
+    }
+    .confirm-buttons {
+      display: flex;
+      gap: 12px;
+      justify-content: center;
+      margin-top: 12px;
+    }
+    .result-box {
+      text-align: center;
+      padding: 18px;
+      margin: 14px 0;
+      border-radius: 8px;
+      background: #e8f5e9;
+      color: #1b5e20;
+    }
+    .result-icon {
+      font-size: 3rem;
+    }
+    .result-message {
+      font-size: 1.2rem;
+      font-weight: 500;
+      margin: 8px 0;
+    }
+  </style>
+</head>
+
+<body class="orange lighten-4">
+  <div th:replace="~{banner::line_judge}"></div>
+  <div th:replace="~{banner::status}"></div>
+
+  <div class="section no-pad-bot orange lighten-4" id="index-banner">
+    <div class="container orange lighten-4 black-text">
+
+      <div class="header-row">
+        <h2 class="heading">Zero Unflown Rounds</h2>
+        <div class="nav-buttons">
+          <a href="#" id="wizardBackBtn" class="waves-effect waves-light btn blue-grey admin-nav-btn" style="display:none;">
+            <i class="material-icons left">arrow_back</i>Back
+          </a>
+          <a href="/admin/scores" class="waves-effect waves-light btn green admin-nav-btn">
+            <i class="material-icons left">arrow_back</i>Score Fixes
+          </a>
+          <a href="/" class="waves-effect waves-light btn teal admin-nav-btn">
+            <i class="material-icons left">exit_to_app</i>Exit
+          </a>
+        </div>
+      </div>
+
+      <div id="wizardContext" class="wizard-context" style="display:none;"></div>
+
+      <!-- Step 0: class/type picker -->
+      <div class="wizard-step" id="step-picker">
+        <div id="loadingState" class="loading-spinner">
+          <div class="preloader-wrapper big active">
+            <div class="spinner-layer spinner-blue-only">
+              <div class="circle-clipper left"><div class="circle"></div></div>
+              <div class="gap-patch"><div class="circle"></div></div>
+              <div class="circle-clipper right"><div class="circle"></div></div>
+            </div>
+          </div>
+          <p>Scanning for groups to zero...</p>
+        </div>
+
+        <div id="noEligible" class="all-clear" style="display:none;">
+          <i class="material-icons">check_circle</i>
+          <div class="all-clear-title">All pilot rounds in sync — nothing to zero</div>
+        </div>
+
+        <div id="pickerWrap" style="display:none;">
+          <div class="step-section-title">Pick a class and round type:</div>
+          <div id="pickerRows"></div>
+        </div>
+      </div>
+
+      <!-- Step 2a: pilot pick -->
+      <div class="wizard-step" id="step-pilot-pick" style="display:none;">
+        <div class="step-section-title">Pick pilot to zero:</div>
+        <div id="pilotPickList"></div>
+      </div>
+
+      <!-- Step 2b: round pick -->
+      <div class="wizard-step" id="step-round-pick" style="display:none;">
+        <div id="roundPickTitle" class="step-section-title"></div>
+        <div id="roundPickList"></div>
+      </div>
+
+      <!-- Step 3: confirm -->
+      <div class="wizard-step" id="step-confirm" style="display:none;">
+        <div class="confirm-box" id="confirmBox"></div>
+        <div class="confirm-buttons">
+          <a href="#" id="confirmCancelBtn" class="waves-effect waves-light btn-flat">Cancel</a>
+          <a href="#" id="confirmActionBtn" class="waves-effect waves-light btn green">Confirm Zero-fill</a>
+        </div>
+      </div>
+
+      <!-- Step 4: result -->
+      <div class="wizard-step" id="step-result" style="display:none;">
+        <div class="result-box">
+          <i class="material-icons result-icon">check_circle</i>
+          <div class="result-message">Round zeroed.</div>
+        </div>
+        <div class="confirm-buttons">
+          <a href="/admin/scores" class="waves-effect waves-light btn green">Done</a>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!--  Scripts-->
+  <script src="/jquery-3.6.4.min.js"></script>
+  <script src="/materialize/js/materialize.js"></script>
+  <script>
+    /* Zero-fill wizard — single-page state machine. */
+    const state = {
+      group: null,           // selected (class, roundType) group
+      targetPilot: null,     // selected pilot
+      targetRound: null,     // selected round
+      allGroups: []
+    };
+    const stepHistory = [];
+
+    function showStep(stepId, recordHistory) {
+      $('.wizard-step').hide();
+      $('#' + stepId).show();
+      if (recordHistory !== false) stepHistory.push(stepId);
+      const showBack = stepHistory.length > 1
+          && stepId !== 'step-picker'
+          && stepId !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(stepId);
+    }
+
+    function goBack() {
+      stepHistory.pop();
+      const prev = stepHistory[stepHistory.length - 1] || 'step-picker';
+      $('.wizard-step').hide();
+      $('#' + prev).show();
+      const showBack = stepHistory.length > 1
+          && prev !== 'step-picker'
+          && prev !== 'step-result';
+      $('#wizardBackBtn').toggle(showBack);
+      updateContextStrip(prev);
+    }
+
+    function updateContextStrip(stepId) {
+      const $ctx = $('#wizardContext');
+      if (!state.group || stepId === 'step-picker') {
+        $ctx.hide().text('');
+        return;
+      }
+      $ctx.text('Zero-fill: ' + state.group.className + ' — ' + roundTypeLabel(state.group.roundType)).show();
+    }
+
+    function roundTypeLabel(rt) {
+      if (rt === 'KNOWN') return 'Known Rounds';
+      if (rt === 'UNKNOWN') return 'Unknown Rounds';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function roundTypeTitle(rt) {
+      if (rt === 'KNOWN') return 'Known';
+      if (rt === 'UNKNOWN') return 'Unknown';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function isEligiblePilot(p, group) {
+      return p.incompleteRound == null && p.roundCount < group.maxCount;
+    }
+
+    function groupHasEligible(g) {
+      return (g.pilots || []).some(function (p) { return isEligiblePilot(p, g); });
+    }
+
+    function fetchGroups() {
+      $('#loadingState').show();
+      $('#noEligible').hide();
+      $('#pickerWrap').hide();
+      $.ajax({
+        url: '/api/scores/mismatches',
+        cache: false,
+        type: 'GET',
+        dataType: 'json',
+        success: function (data) {
+          state.allGroups = (data.allGroups || []).filter(groupHasEligible);
+          renderPicker();
+        },
+        error: function () {
+          $('#loadingState').hide();
+          M.toast({ html: 'Could not load detection data', classes: 'red' });
+        }
+      });
+    }
+
+    function renderPicker() {
+      $('#loadingState').hide();
+      if (state.allGroups.length === 0) {
+        $('#noEligible').show();
+        $('#pickerWrap').hide();
+        return;
+      }
+      $('#noEligible').hide();
+      $('#pickerWrap').show();
+      const $rows = $('#pickerRows').empty();
+
+      const byClass = {};
+      let freestyle = null;
+      state.allGroups.forEach(function (g) {
+        if (g.className === 'FREESTYLE') {
+          freestyle = g;
+          return;
+        }
+        if (!byClass[g.className]) byClass[g.className] = [];
+        byClass[g.className].push(g);
+      });
+
+      Object.keys(byClass).forEach(function (className) {
+        const groups = byClass[className];
+        const $row = $('<div class="picker-class-row">');
+        $row.append($('<div class="picker-class-label">').text(className));
+        ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
+          const g = groups.find(function (x) { return x.roundType === rt; });
+          if (!g) return;
+          const $btn = $('<a href="#" class="picker-type-btn">').text(roundTypeTitle(rt));
+          $btn.on('click', function (e) {
+            e.preventDefault();
+            state.group = g;
+            stepHistory.length = 0;
+            stepHistory.push('step-picker');
+            showStep('step-pilot-pick');
+            renderPilotPick();
+          });
+          $row.append($btn);
+        });
+        $rows.append($row);
+      });
+
+      if (freestyle) {
+        $rows.append($('<div class="picker-divider">'));
+        const $fsRow = $('<div class="picker-freestyle-row">');
+        const $btn = $('<a href="#" class="picker-type-btn">').text('Freestyle');
+        $btn.on('click', function (e) {
+          e.preventDefault();
+          state.group = freestyle;
+          stepHistory.length = 0;
+          stepHistory.push('step-picker');
+          showStep('step-pilot-pick');
+          renderPilotPick();
+        });
+        $fsRow.append($btn);
+        $rows.append($fsRow);
+      }
+    }
+
+    function renderPilotPick() {
+      const $list = $('#pilotPickList').empty();
+      const pilots = (state.group.pilots || []).slice()
+          .sort(function (a, b) { return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }); });
+      const maxC = state.group.maxCount;
+      pilots.forEach(function (p) {
+        const $row = $('<a href="#" class="pick-row">');
+        $row.append($('<div class="row-name">').text(p.name));
+        const meta = p.roundCount + ' ' + roundTypeTitle(state.group.roundType) + ' rounds';
+        $row.append($('<div class="row-meta">').text(meta));
+        let disabled = false;
+        let caption = null;
+        if (p.incompleteRound != null) {
+          disabled = true;
+          caption = 'Mark missing sequence first';
+        } else if (p.roundCount >= maxC) {
+          disabled = true;
+          caption = 'Already caught up';
+        }
+        if (caption) $row.append($('<div class="row-caption">').text(caption));
+        if (disabled) {
+          $row.addClass('disabled');
+        } else {
+          $row.on('click', function (e) {
+            e.preventDefault();
+            state.targetPilot = p;
+            showStep('step-round-pick');
+            renderRoundPick();
+          });
+        }
+        $list.append($row);
+      });
+    }
+
+    function renderRoundPick() {
+      $('#roundPickTitle').text('Pick round to zero for ' + state.targetPilot.name + ':');
+      const $list = $('#roundPickList').empty();
+      const start = state.targetPilot.roundCount + 1;
+      const end = state.group.maxCount;
+      for (let r = start; r <= end; r++) {
+        const round = r;
+        const $row = $('<a href="#" class="round-pick-row">');
+        $row.append($('<div>').text(roundTypeTitle(state.group.roundType) + ' Round ' + round));
+        if (round === start) {
+          $row.on('click', function (e) {
+            e.preventDefault();
+            state.targetRound = round;
+            showStep('step-confirm');
+            renderConfirm();
+          });
+        } else {
+          $row.addClass('disabled');
+          $row.append($('<div class="row-caption">').text('Zero Round ' + start + ' first'));
+        }
+        $list.append($row);
+      }
+    }
+
+    function renderConfirm() {
+      const p = state.targetPilot;
+      const typeTitle = roundTypeTitle(state.group.roundType);
+      const $box = $('#confirmBox').empty();
+      $box.append($('<div class="confirm-action">').text(
+          'Add zero scores for ' + typeTitle + ' Round ' + state.targetRound + ' to ' + p.name + '.'));
+      const afterCount = state.targetRound;
+      $box.append($('<div class="confirm-after-line">').text(
+          'After: ' + afterCount + ' ' + typeTitle + ' rounds (next: Round ' + (afterCount + 1) + ').'));
+    }
+
+    function executeZeroFill() {
+      $.ajax({
+        url: '/api/scores/zero-fill',
+        cache: false,
+        type: 'POST',
+        contentType: 'application/json; charset=utf-8',
+        dataType: 'json',
+        data: JSON.stringify({
+          pilotId: state.targetPilot.pilotId,
+          roundType: state.group.roundType,
+          round: state.targetRound
+        }),
+        success: function (data) {
+          if (data.result === 'ok') {
+            showStep('step-result');
+          } else {
+            M.toast({ html: data.message || 'Zero-fill failed', classes: 'red' });
+          }
+        },
+        error: function (errObj) {
+          const msg = errObj.responseJSON && errObj.responseJSON.message
+              ? errObj.responseJSON.message
+              : 'Zero-fill failed';
+          M.toast({ html: msg, classes: 'red' });
+        }
+      });
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+      stepHistory.push('step-picker');
+      fetchGroups();
+    });
+
+    $('#wizardBackBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#confirmCancelBtn').on('click', function (e) {
+      e.preventDefault();
+      goBack();
+    });
+
+    $('#confirmActionBtn').on('click', function (e) {
+      e.preventDefault();
+      executeZeroFill();
+    });
+  </script>
+
+</body>
+
+</html>

--- a/judge/src/main/resources/templates/adminScoresZeroFill.html
+++ b/judge/src/main/resources/templates/adminScoresZeroFill.html
@@ -64,15 +64,22 @@
     .picker-class-row {
       display: flex;
       align-items: center;
+      justify-content: space-between;
       gap: 8px;
-      padding: 6px 0;
+      padding: 8px 14px;
+      margin-bottom: 6px;
+      border: 1px solid #90a4ae;
+      border-radius: 6px;
     }
     .picker-class-label {
-      flex: 0 0 130px;
       font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
+    }
+    .picker-class-btns {
+      display: flex;
+      gap: 8px;
     }
     .picker-type-btn {
       padding: 8px 14px;
@@ -396,6 +403,7 @@
         const groups = byClass[className];
         const $row = $('<div class="picker-class-row">');
         $row.append($('<div class="picker-class-label">').text(className));
+        const $btns = $('<div class="picker-class-btns">');
         ['KNOWN', 'UNKNOWN'].forEach(function (rt) {
           const g = groups.find(function (x) { return x.roundType === rt; });
           if (!g) return;
@@ -408,14 +416,16 @@
             showStep('step-pilot-pick');
             renderPilotPick();
           });
-          $row.append($btn);
+          $btns.append($btn);
         });
+        $row.append($btns);
         $rows.append($row);
       });
 
       if (freestyle) {
-        $rows.append($('<div class="picker-divider">'));
-        const $fsRow = $('<div class="picker-freestyle-row">');
+        const $row = $('<div class="picker-class-row">');
+        $row.append($('<div class="picker-class-label">').text('FREESTYLE'));
+        const $btns = $('<div class="picker-class-btns">');
         const $btn = $('<a href="#" class="picker-type-btn">').text('Freestyle');
         $btn.on('click', function (e) {
           e.preventDefault();
@@ -425,8 +435,9 @@
           showStep('step-pilot-pick');
           renderPilotPick();
         });
-        $fsRow.append($btn);
-        $rows.append($fsRow);
+        $btns.append($btn);
+        $row.append($btns);
+        $rows.append($row);
       }
     }
 

--- a/judge/src/main/resources/templates/adminScoresZeroFill.html
+++ b/judge/src/main/resources/templates/adminScoresZeroFill.html
@@ -15,8 +15,7 @@
       align-items: center;
       justify-content: space-between;
       flex-wrap: wrap;
-      margin-top: 10px;
-      margin-bottom: 8px;
+      margin: 10px 0 6px 0;
     }
     .heading {
       font-size: calc(1.2vw + 2vh) !important;
@@ -32,30 +31,30 @@
       padding: 0 12px;
     }
     .wizard-context {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 500;
       color: #455a64;
-      margin: 4px 0 12px;
+      margin: 4px 0 8px;
     }
     .step-section-title {
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       color: #455a64;
-      margin: 10px 0 8px;
+      margin: 8px 0 6px 0;
     }
     .all-clear {
       text-align: center;
-      padding: 16px;
+      padding: 16px 10px;
       color: #2e7d32;
     }
     .all-clear i {
       font-size: 3.5rem;
       color: #4caf50;
       display: block;
-      margin-bottom: 8px;
+      margin-bottom: 6px;
     }
     .all-clear-title {
-      font-size: 1.2rem;
+      font-size: 2.1rem;
       font-weight: 500;
     }
     .loading-spinner {
@@ -69,18 +68,19 @@
       padding: 6px 0;
     }
     .picker-class-label {
-      flex: 0 0 110px;
+      flex: 0 0 130px;
+      font-size: 1.9rem;
       font-weight: 600;
       text-transform: uppercase;
       color: #263238;
     }
     .picker-type-btn {
-      padding: 6px 14px;
+      padding: 8px 14px;
       border: 2px solid #90a4ae;
       border-radius: 6px;
       background: #fafafa;
       color: #263238;
-      font-size: 0.95rem;
+      font-size: 1.75rem;
       cursor: pointer;
       text-decoration: none;
     }
@@ -102,7 +102,7 @@
       border: 2px solid #90a4ae;
       border-radius: 8px;
       background: #fafafa;
-      font-size: 1rem;
+      font-size: 1.75rem;
       color: #263238;
       cursor: pointer;
       text-decoration: none;
@@ -114,19 +114,20 @@
       font-weight: 500;
     }
     .pick-row .row-meta {
-      font-size: 0.9rem;
+      font-size: 1.5rem;
       color: #555;
     }
     .pick-row.disabled {
       background: #e0e0e0;
       color: #757575;
       border-color: #bdbdbd;
-      cursor: default;
+      cursor: not-allowed;
     }
     .pick-row.disabled .row-meta,
     .pick-row .row-caption {
       color: #616161;
-      font-size: 0.85rem;
+      font-size: 1.5rem;
+      margin-top: 3px;
     }
     .round-pick-row {
       display: block;
@@ -136,7 +137,7 @@
       border-radius: 8px;
       background: #e3f2fd;
       color: #0d47a1;
-      font-size: 1.1rem;
+      font-size: 1.9rem;
       font-weight: 600;
       text-align: center;
       cursor: pointer;
@@ -149,40 +150,41 @@
       background: #e0e0e0;
       color: #757575;
       border-color: #bdbdbd;
-      cursor: default;
+      cursor: not-allowed;
     }
     .round-pick-row .row-caption {
-      font-size: 0.85rem;
+      font-size: 1.5rem;
       color: #616161;
       font-weight: 400;
+      margin-top: 3px;
     }
     .confirm-box {
       border: 2px solid #1976d2;
       border-radius: 8px;
-      padding: 12px 16px;
+      padding: 10px 14px;
       background: #e3f2fd;
       color: #0d47a1;
-      margin: 10px 0;
+      margin-bottom: 10px;
     }
     .confirm-action {
-      font-size: 1.1rem;
+      font-size: 1.75rem;
       font-weight: 600;
       margin-bottom: 8px;
     }
     .confirm-after-line {
-      font-size: 1rem;
+      font-size: 1.75rem;
       margin: 4px 0;
     }
     .confirm-buttons {
       display: flex;
-      gap: 12px;
+      gap: 10px;
       justify-content: center;
-      margin-top: 12px;
+      margin-top: 8px;
     }
     .result-box {
       text-align: center;
-      padding: 18px;
-      margin: 14px 0;
+      padding: 12px 16px;
+      margin: 10px 0;
       border-radius: 8px;
       background: #e8f5e9;
       color: #1b5e20;
@@ -191,7 +193,7 @@
       font-size: 3rem;
     }
     .result-message {
-      font-size: 1.2rem;
+      font-size: 1.75rem;
       font-weight: 500;
       margin: 8px 0;
     }

--- a/judge/src/main/resources/templates/error.html
+++ b/judge/src/main/resources/templates/error.html
@@ -81,7 +81,7 @@
       <p style="font-size: 1rem; color: #666;">Changes made here may affect the competition setup.</p>
     </div>
     <div class="modal-footer" style="text-align: center;">
-      <a href="/admin/comp" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
+      <a href="/admin" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
       <a href="#!" class="modal-close waves-effect waves-red btn red" style="text-align: center; width: 120px;">Exit</a>
     </div>
   </div>

--- a/judge/src/main/resources/templates/pilot-list-global.html
+++ b/judge/src/main/resources/templates/pilot-list-global.html
@@ -134,7 +134,7 @@
       <p style="font-size: 1rem; color: #666;">Changes made here may affect the competition setup.</p>
     </div>
     <div class="modal-footer" style="text-align: center;">
-      <a href="/admin/comp" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
+      <a href="/admin" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
       <a href="#!" class="modal-close waves-effect waves-red btn red" style="text-align: center; width: 120px;">Exit</a>
     </div>
   </div>

--- a/judge/src/main/resources/templates/pilot-list-global.html
+++ b/judge/src/main/resources/templates/pilot-list-global.html
@@ -125,6 +125,9 @@
 
   <div th:replace="~{class_filter_modal::class_filter_modal}"></div>
 
+  <!-- Pre-sync mismatch warning modal (shared fragment) -->
+  <div th:replace="~{sync-mismatch-modal :: modal}"></div>
+
   <!-- Admin Warning Modal -->
   <div id="admin_warning_modal" class="modal">
     <div class="modal-content center-align">
@@ -244,17 +247,63 @@
     }
 
     async function syncScores() {
+      let payload = null;
       try {
-        const response = await $.ajax({
-          url: "/api/scores/sync"
+        payload = await $.ajax({
+          url: '/api/scores/mismatches',
+          cache: false,
+          dataType: 'json'
         });
-
-        M.toast({ html: 'Scores Sync Success', classes: 'toastMessage', displayLength: 4000 })
-
-      } catch (errMsg) {
-          M.toast({ html: 'Scores Sync Error - Is Score Available?', classes: 'toastMessage', displayLength: 4000 })
+      } catch (e) {
+        // Pre-flight failed — fall through to sync without modal
       }
+      if (payload && payload.mismatches && payload.mismatches.length > 0) {
+        populateAndOpenSyncMismatchModal(payload);
+        return;
+      }
+      doActualSync();
     }
+
+    function doActualSync() {
+      $.ajax({ url: '/api/scores/sync' })
+        .done(function () {
+          M.toast({ html: 'Scores Sync Success', classes: 'toastMessage', displayLength: 4000 });
+        })
+        .fail(function () {
+          M.toast({ html: 'Scores Sync Error - Is Score Available?', classes: 'toastMessage', displayLength: 4000 });
+        });
+    }
+
+    function syncMismatchRoundTypeLabel(rt) {
+      if (rt === 'KNOWN') return 'Known';
+      if (rt === 'UNKNOWN') return 'Unknown';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function populateAndOpenSyncMismatchModal(payload) {
+      const $list = $('#syncMismatchList').empty();
+      (payload.mismatches || []).forEach(function (g) {
+        const groupLabel = g.className + ' ' + syncMismatchRoundTypeLabel(g.roundType);
+        if ((g.anomalies || []).indexOf('count_gap') !== -1) {
+          $list.append($('<li>').text(groupLabel + ': counts span ' + g.minCount + ' to ' + g.maxCount));
+        }
+        if ((g.anomalies || []).indexOf('incomplete_round') !== -1) {
+          (g.pilots || []).forEach(function (p) {
+            if (p.incompleteRound != null) {
+              $list.append($('<li>').text(
+                  groupLabel + ': ' + p.name + ' — Round ' + p.incompleteRound + ' incomplete (sequence 2 missing)'));
+            }
+          });
+        }
+      });
+      const modal = M.Modal.getInstance(document.getElementById('syncMismatchModal'));
+      modal.open();
+    }
+
+    $(document).on('click', '#syncAnywayBtn', function () {
+      doActualSync();
+    });
 
     // Instructions audio for new users
     var instructionsAudio = null;

--- a/judge/src/main/resources/templates/pilot-list-round.html
+++ b/judge/src/main/resources/templates/pilot-list-round.html
@@ -123,7 +123,7 @@
     <p style="font-size: 1.2rem; color: #ff0000;">Changes made here may affect the competition setup.</p>
   </div>
     <div class="modal-footer" style="text-align: center;">
-      <a href="/admin/comp" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
+      <a href="/admin" class="waves-effect waves-green btn green" style="text-align: center; width: 120px; margin-right: 60px;">Continue</a>
       <a href="#!" class="modal-close waves-effect waves-red btn red" style="text-align: center; width: 120px;">Exit</a>
     </div>
 </div>

--- a/judge/src/main/resources/templates/pilot-list-round.html
+++ b/judge/src/main/resources/templates/pilot-list-round.html
@@ -115,6 +115,9 @@
 </div>
 
 <!-- Admin Warning Modal -->
+<!-- Pre-sync mismatch warning modal (shared fragment) -->
+<div th:replace="~{sync-mismatch-modal :: modal}"></div>
+
 <div id="admin_warning_modal" class="modal">
   <div class="modal-content center-align">
     <h4><i class="material-icons medium orange-text">warning</i></h4>
@@ -234,17 +237,63 @@
     }
 
     async function syncScores() {
+      let payload = null;
       try {
-        const response = await $.ajax({
-          url: "/api/scores/sync"
+        payload = await $.ajax({
+          url: '/api/scores/mismatches',
+          cache: false,
+          dataType: 'json'
         });
-
-        M.toast({ html: 'Scores Sync Success', classes: 'toastMessage', displayLength: 4000 })
-
-      } catch (errMsg) {
-          M.toast({ html: 'Scores Sync Error - Is Score Available?', classes: 'toastMessage', displayLength: 4000 })
+      } catch (e) {
+        // Pre-flight failed — fall through to sync without modal
       }
+      if (payload && payload.mismatches && payload.mismatches.length > 0) {
+        populateAndOpenSyncMismatchModal(payload);
+        return;
+      }
+      doActualSync();
     }
+
+    function doActualSync() {
+      $.ajax({ url: '/api/scores/sync' })
+        .done(function () {
+          M.toast({ html: 'Scores Sync Success', classes: 'toastMessage', displayLength: 4000 });
+        })
+        .fail(function () {
+          M.toast({ html: 'Scores Sync Error - Is Score Available?', classes: 'toastMessage', displayLength: 4000 });
+        });
+    }
+
+    function syncMismatchRoundTypeLabel(rt) {
+      if (rt === 'KNOWN') return 'Known';
+      if (rt === 'UNKNOWN') return 'Unknown';
+      if (rt === 'FREESTYLE') return 'Freestyle';
+      return rt;
+    }
+
+    function populateAndOpenSyncMismatchModal(payload) {
+      const $list = $('#syncMismatchList').empty();
+      (payload.mismatches || []).forEach(function (g) {
+        const groupLabel = g.className + ' ' + syncMismatchRoundTypeLabel(g.roundType);
+        if ((g.anomalies || []).indexOf('count_gap') !== -1) {
+          $list.append($('<li>').text(groupLabel + ': counts span ' + g.minCount + ' to ' + g.maxCount));
+        }
+        if ((g.anomalies || []).indexOf('incomplete_round') !== -1) {
+          (g.pilots || []).forEach(function (p) {
+            if (p.incompleteRound != null) {
+              $list.append($('<li>').text(
+                  groupLabel + ': ' + p.name + ' — Round ' + p.incompleteRound + ' incomplete (sequence 2 missing)'));
+            }
+          });
+        }
+      });
+      const modal = M.Modal.getInstance(document.getElementById('syncMismatchModal'));
+      modal.open();
+    }
+
+    $(document).on('click', '#syncAnywayBtn', function () {
+      doActualSync();
+    });
 
     // Instructions audio for new users
     var instructionsAudio = null;

--- a/judge/src/main/resources/templates/sequence_validation.html
+++ b/judge/src/main/resources/templates/sequence_validation.html
@@ -124,6 +124,12 @@
       background-color: #f5f5f5;
       border-radius: 8px;
     }
+    .event-line {
+      font-size: 1.6rem;
+      font-weight: 700;
+      text-align: center;
+      margin: 4px 0 12px;
+    }
   </style>
 </head>
 
@@ -148,6 +154,13 @@
             <i class="material-icons" style="font-size: inherit; vertical-align: middle;">warning</i>
             Sequence Configuration Issues
           </h2>
+        </div>
+      </div>
+
+      <!-- Event name (always visible) -->
+      <div class="row">
+        <div class="col s12">
+          <p class="event-line" th:text="${compName}"></p>
         </div>
       </div>
 

--- a/judge/src/main/resources/templates/sync-mismatch-modal.html
+++ b/judge/src/main/resources/templates/sync-mismatch-modal.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+
+<body>
+  <div th:fragment="modal">
+    <div id="syncMismatchModal" class="modal" style="max-width: 600px;">
+      <div class="modal-content" style="padding: 16px 20px;">
+        <h5 style="font-size: 1.75rem; margin-top: 0;">
+          <i class="material-icons orange-text" style="font-size: 1.5rem; vertical-align: middle; margin-right: 6px;">warning</i>
+          Mismatches detected — admin review recommended before sync.
+        </h5>
+        <ul id="syncMismatchList" style="font-size: 1.75rem; margin: 12px 0; padding-left: 24px; list-style: disc;"></ul>
+        <p style="font-size: 1.5rem; color: #555; margin: 12px 0 0;">
+          Continuing will push uneven data to the score server. Some mistakes can't be detected automatically — when in doubt, get admin before syncing.
+        </p>
+      </div>
+      <div class="modal-footer" style="padding: 10px 20px;">
+        <a href="#!" class="modal-close waves-effect btn-flat" style="font-size: 1.5rem;">Get admin</a>
+        <a href="#!" id="syncAnywayBtn" class="modal-close waves-effect btn-flat" style="font-size: 1.5rem;">Sync anyway</a>
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>


### PR DESCRIPTION
## Summary

Reorganization of `/admin` and `/admin/scores`, plus the score-fix tooling that lives under them.

## Changes

**Mismatch detection + resolver wizards**
- Detection rewrite: deterministic on per-class+type round-count spread.
- New `ScoreResolverService` for pure-logic helpers shared by detection and the resolver flows.
- Three resolver operations as wizards under `/admin/scores`:
  - **Fix Missing Sequence** — zero a missing seq 2 with peer-evidence figure-count borrow.
  - **Move Round** — move a scored round from one pilot to another within the same class+type.
  - **Swap Round** — exchange scored rounds between two pilots in the same class+type.
- **Zero Unflown Rounds** wizard for end-of-round skipped pilots; sequential constraint enforced.
- Bordered class+type picker tiles, plain-language step labels, per-pilot/per-round scope only.

**Format-change preventive blocker**
- Sequence-mode changes (1↔2 KNOWN per round) gated when active-pilot class state isn't clean.
- Two rules: no pilot at activeSequence==2 in KNOWN, all active pilots in a class on the same KNOWN round count.
- Surfaces as 409 + payload + modal on Update Local Settings and Refresh Event flows; applies in both directions.

**Sync gate**
- Pre-sync mismatch modal warns the device operator before pushing scores when local mismatches are detected. Not blocking. 

**Admin restructure**
- New `/admin` landing page with a three-tile menu.
- Page renames: Scorekeeper Admin → Event Admin, Score Admin → Score Fixes.
- Single "Admin Menu" cross-link replaces scattered nav buttons; "Home" → "Exit".
- Current event name displayed on `/admin` and the sequence-validation page.

**Utility / consistency**
- New `ContestClasses` utility consolidates class-order constants.
- Text-size and spacing tiers applied consistently across admin templates.
- Per-type `activeRound` integrity fix.
- `ScheduleService` in-memory cache invalidated after `sequences.dat` re-download in `createComp`.
- Operational checks (mismatch detection, format-change-blocker, move-round / zero-fill / fix-missing-sequence peer lookups) filter to active pilots, matching the carousel and pre-flight validator's existing convention.
